### PR TITLE
fix: poll state unconditionally regardless of available flag

### DIFF
--- a/custom_components/alarmdotcom/hub.py
+++ b/custom_components/alarmdotcom/hub.py
@@ -120,8 +120,6 @@ class AlarmHub:
 
     async def _async_refresh_state(self, _now=None) -> None:
         """Periodically poll full state as a safety net against missed websocket events."""
-        if not self.available:
-            return
         try:
             log.debug("Alarm.com: performing periodic full state refresh.")
             await self.api.initialize()


### PR DESCRIPTION
## Problem

When the WebSocket drops silently — no TCP close frame, which happens with NAT/proxy idle timeouts or Alarm.com session expiry (~3 hours) — `self.available` remains `True` because the `DEAD` state event is never fired. The previous `if not self.available: return` guard in `_async_refresh_state` meant the 5-minute safety-net poll silently no-oped during exactly the failure mode it was designed to catch.

## Fix

Remove the guard so the periodic poll always runs regardless of connection state. This bounds stale state after a silent drop to ~5 minutes instead of being unbounded.

## Context

I originally reported this as #20. The state-write typo fixed in 2026.5.3 addressed WebSocket events being discarded when the connection was alive — this addresses the complementary failure mode where the connection appears alive but is dead.

Tested on my own HA instance over several weeks with no issues.