### PR TITLE
fix: add WebSocket heartbeat to detect silent connection drops

### DIFF
--- a/custom_components/alarmdotcom/hub.py
+++ b/custom_components/alarmdotcom/hub.py
@@ -1,6 +1,7 @@
 """Controller interfaces with the Alarm.com API via pyalarmdotcomajax."""
 
 import asyncio
+import contextlib
 import logging
 from datetime import timedelta
 
@@ -29,6 +30,28 @@ POLLING_INTERVAL = timedelta(minutes=5)
 WS_RECONNECT_DELAY = 30  # seconds
 WS_MAX_RECONNECT_ATTEMPTS = 5
 
+WS_HEARTBEAT_INTERVAL = 60  # seconds
+
+
+class _AlarmBridgeWithHeartbeat(AlarmBridge):
+    """AlarmBridge subclass that injects a WebSocket heartbeat.
+
+    aiohttp sends a PING frame every WS_HEARTBEAT_INTERVAL seconds and closes
+    the connection if no PONG is received, triggering the existing reconnect
+    logic. This catches silent drops (no TCP close frame) that the library's
+    HTTP-based keep-alive misses, e.g. NAT/proxy idle timeouts after ~3 hours.
+    """
+
+    @contextlib.asynccontextmanager
+    async def ws_connect(self, url, **kwargs):
+        if self._websession is None:
+            raise pyadc.NotInitialized(
+                "Cannot initiate WebSocket connection without an existing session."
+            )
+        kwargs.setdefault("heartbeat", WS_HEARTBEAT_INTERVAL)
+        async with self._websession.ws_connect(url, **kwargs) as res:
+            yield res
+
 
 class AlarmHub:
     """Config-entry initiated Alarm Hub."""
@@ -38,7 +61,7 @@ class AlarmHub:
         self.hass: HomeAssistant = hass
         self.config_entry: ConfigEntry = config_entry
 
-        self.api = AlarmBridge(
+        self.api = _AlarmBridgeWithHeartbeat(
             username=config_entry.data[CONF_USERNAME],
             password=config_entry.data[CONF_PASSWORD],
             mfa_token=config_entry.data.get(CONF_MFA_TOKEN),


### PR DESCRIPTION
## Problem

Alarm.com's WebSocket can die silently — no TCP close frame — due to NAT/proxy idle timeouts or Alarm.com session expiry (~3 hours). When this happens:

- `aiohttp`'s `recv()` hangs indefinitely
- No `DEAD` state event is ever fired
- The integration believes the connection is alive
- External arm/disarm events (keypad, physical sensors) are never received until the next full reconnect

The library's existing keep-alive is HTTP-only (session token refresh), not a WebSocket PING/PONG heartbeat, so it does not catch this failure mode.

## Fix

Adds `_AlarmBridgeWithHeartbeat`, a minimal `AlarmBridge` subclass that overrides `ws_connect()` to inject `heartbeat=60` via `**kwargs`. aiohttp then sends a PING frame every 60 seconds; if no PONG is received it closes the connection and raises, triggering the existing reconnect logic in `_ws_state_handler`.

No changes to `pyalarmdotcomajax` are required — the `**kwargs` passthrough already exists in `AlarmBridge.ws_connect()`.

## Context

Originally reported in #20. This fix and the polling guard fix (PR #34) address the silent-drop failure mode that the state-write typo fix in 2026.5.3 did not cover.

Tested on my own HA instance for several weeks. The `[heartbeat]` PING/PONG frames are visible in aiohttp debug logs and connections that previously went stale for hours now reconnect within ~60 seconds.