### PR TITLE
feat: add alarmdotcom.refresh_connection service

### DIFF
--- a/custom_components/alarmdotcom/__init__.py
+++ b/custom_components/alarmdotcom/__init__.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
     SERVICE_BYPASS_SENSOR,
+    SERVICE_REFRESH_CONNECTION,
     SERVICE_UNBYPASS_SENSOR,
     STARTUP_MESSAGE,
 )
@@ -173,6 +174,17 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             schema=service_schema,
         )
 
+    async def handle_refresh_connection_service(call: ServiceCall) -> None:
+        """Handle the alarmdotcom.refresh_connection service call."""
+        await hub.async_refresh_connection()
+
+    if not hass.services.has_service(DOMAIN, SERVICE_REFRESH_CONNECTION):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_REFRESH_CONNECTION,
+            handle_refresh_connection_service,
+        )
+
     LOGGER.info("%s: Finished initializing Alarmdotcom from config entry.", __name__)
     return True
 
@@ -303,5 +315,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
             hass.services.async_remove(DOMAIN, SERVICE_BYPASS_SENSOR)
         if hass.services.has_service(DOMAIN, SERVICE_UNBYPASS_SENSOR):
             hass.services.async_remove(DOMAIN, SERVICE_UNBYPASS_SENSOR)
+        if hass.services.has_service(DOMAIN, SERVICE_REFRESH_CONNECTION):
+            hass.services.async_remove(DOMAIN, SERVICE_REFRESH_CONNECTION)
 
     return unload_success

--- a/custom_components/alarmdotcom/const.py
+++ b/custom_components/alarmdotcom/const.py
@@ -22,6 +22,7 @@ DEBUG_REQ_EVENT = "alarmdotcom_debug_request"
 
 SERVICE_BYPASS_SENSOR = "bypass_sensor"
 SERVICE_UNBYPASS_SENSOR = "unbypass_sensor"
+SERVICE_REFRESH_CONNECTION = "refresh_connection"
 ATTR_RESOURCE_ID = "resource_id"
 ATTR_PARTITION_ID = "partition_id"
 

--- a/custom_components/alarmdotcom/hub.py
+++ b/custom_components/alarmdotcom/hub.py
@@ -118,6 +118,24 @@ class AlarmHub:
         self._reconnect_attempts = 0
         return True
 
+    async def async_refresh_connection(self) -> None:
+        """Force a state refresh or reconnect. Callable via the alarmdotcom.refresh_connection service."""
+        if not self.available:
+            log.info("Alarm.com: refresh_connection called while unavailable, triggering reconnect.")
+            await self._async_handle_ws_death()
+            return
+
+        try:
+            log.debug("Alarm.com: refresh_connection — fetching full state.")
+            await self.api.initialize()
+        except pyadc.AuthenticationException:
+            log.warning("Alarm.com: refresh_connection failed — auth error, triggering reconnect.")
+            await self._async_handle_ws_death()
+        except Exception as err:
+            log.warning("Alarm.com: refresh_connection failed: %s. Marking unavailable and reconnecting.", err)
+            self.available = False
+            await self._async_handle_ws_death()
+
     async def _async_refresh_state(self, _now=None) -> None:
         """Periodically poll full state as a safety net against missed websocket events."""
         if not self.available:

--- a/custom_components/alarmdotcom/services.yaml
+++ b/custom_components/alarmdotcom/services.yaml
@@ -34,3 +34,8 @@ unbypass_sensor:
       example: "20392030"
       selector:
         text:
+refresh_connection:
+  name: Refresh Connection
+  description: >
+    Force a health check and full state refresh of the Alarm.com connection.
+    If the connection is stale or dead, triggers a reconnect.


### PR DESCRIPTION
## Summary

Adds a new HA service `alarmdotcom.refresh_connection` that forces an immediate state refresh or triggers a reconnect on demand — without waiting for the 5-minute polling interval.

## Use cases

**Manual recovery:** Call the service from Developer Tools after suspecting a stale connection.

**Automation watchdog:** Pair with local Zigbee/Z-Wave sensors to detect when HA has real-world activity but the alarm panel state hasn't updated in a while:

```yaml
alias: "Alarm.com Zigbee Watchdog"
trigger:
  - platform: state
    entity_id: binary_sensor.front_door_contact
condition:
  - condition: template
    value_template: >
      {{ (now() - states.alarm_control_panel.your_panel.last_updated).total_seconds() > 600 }}
action:
  - service: alarmdotcom.refresh_connection
```

## Changes

- `const.py`: adds `SERVICE_REFRESH_CONNECTION` constant
- `hub.py`: adds `async_refresh_connection()` — fetches state if connected, triggers reconnect if `available` is False, handles exceptions gracefully
- `__init__.py`: registers the service on setup and removes it cleanly on unload

## Note

This PR is independent of PRs #34 and #35 but is most useful in combination with them.