### PR TITLE
fix(hub): add WebSocket heartbeat and unconditional state polling

### DIFF
--- a/custom_components/alarmdotcom/hub.py
+++ b/custom_components/alarmdotcom/hub.py
@@ -1,6 +1,7 @@
 """Controller interfaces with the Alarm.com API via pyalarmdotcomajax."""
 
 import asyncio
+import contextlib
 import logging
 from datetime import timedelta
 
@@ -29,6 +30,27 @@ POLLING_INTERVAL = timedelta(minutes=5)
 WS_RECONNECT_DELAY = 30  # seconds
 WS_MAX_RECONNECT_ATTEMPTS = 5
 
+WS_HEARTBEAT_INTERVAL = 60  # seconds
+
+
+class _AlarmBridgeWithHeartbeat(AlarmBridge):
+    """AlarmBridge subclass that injects a WebSocket heartbeat.
+
+    aiohttp will send a PING frame every WS_HEARTBEAT_INTERVAL seconds and
+    close the connection if no PONG is received, triggering reconnection.
+    This catches silent drops that the library's HTTP-based keep-alive misses.
+    """
+
+    @contextlib.asynccontextmanager
+    async def ws_connect(self, url, **kwargs):
+        if self._websession is None:
+            raise pyadc.NotInitialized(
+                "Cannot initiate WebSocket connection without an existing session."
+            )
+        kwargs.setdefault("heartbeat", WS_HEARTBEAT_INTERVAL)
+        async with self._websession.ws_connect(url, **kwargs) as res:
+            yield res
+
 
 class AlarmHub:
     """Config-entry initiated Alarm Hub."""
@@ -38,7 +60,7 @@ class AlarmHub:
         self.hass: HomeAssistant = hass
         self.config_entry: ConfigEntry = config_entry
 
-        self.api = AlarmBridge(
+        self.api = _AlarmBridgeWithHeartbeat(
             username=config_entry.data[CONF_USERNAME],
             password=config_entry.data[CONF_PASSWORD],
             mfa_token=config_entry.data.get(CONF_MFA_TOKEN),
@@ -120,11 +142,9 @@ class AlarmHub:
 
     async def _async_refresh_state(self, _now=None) -> None:
         """Periodically poll full state as a safety net against missed websocket events."""
-        if not self.available:
-            return
         try:
             log.debug("Alarm.com: performing periodic full state refresh.")
-            await self.api.initialize()
+            await self.api.fetch_full_state()
         except pyadc.AuthenticationException:
             log.warning("Alarm.com: periodic refresh failed — auth error. Will attempt reconnect.")
             await self._async_handle_ws_death()


### PR DESCRIPTION
## Problem

Two reliability issues cause Alarm.com state to go stale in HA:

1. **Silent WebSocket drops** — aiohttp connections can drop at the TCP
   level without the library detecting it. The existing HTTP-based
   keep-alive doesn't catch this. The result is a "connected" WebSocket
   that delivers no events.

2. **Polling suppressed during outages** — `_async_refresh_state` skipped
   polling when `self.available` was False, meaning a dead connection also
   stopped the safety-net poll. State could go stale indefinitely until
   a full reconnect completed.

## Fix

**1. WebSocket heartbeat (`_AlarmBridgeWithHeartbeat`)**
Subclasses `AlarmBridge.ws_connect()` to inject `heartbeat=60` into the
aiohttp `ws_connect()` call. aiohttp sends a PING every 60 seconds and
closes the connection if no PONG is received, triggering the existing
reconnect logic automatically.

PING/PONG frames are protocol-level control frames defined in RFC 6455.
They are handled at the transport layer of the existing WebSocket
connection — not HTTP requests — and do not count against API rate limits.

**2. Unconditional polling via `fetch_full_state()`**
Removes the `if not self.available: return` guard and replaces
`api.initialize()` with `api.fetch_full_state()`, which has no
`_initialized` guard and performs a full HTTP state fetch every 5 minutes
regardless of WebSocket state.

## Testing

Validated on live system (ibasebcast 2026.5.3 base):
- Door open/close reflected in HA within 1–20 seconds
- Arm/disarm reflected immediately
- Stable for 30+ minutes with no staleness

---
*Written and reviewed with [Claude Code](https://claude.ai/code) (Anthropic)*