### PR TITLE
Quality Scale improvements and a few other stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ Some Alarm.com providers may restrict combinations of these options.
 
 ---
 
+# Services
+
+This integration exposes the following services, callable from **Developer Tools → Actions**, automations, or scripts.
+
+| Service                       | Purpose                                                          | Target                        |
+| ------------------------------ | ----------------------------------------------------------------- | ------------------------------ |
+| `alarmdotcom.bypass_sensor`    | Bypass a supported sensor (e.g. a door left open) for the current arm period | `resource_id` field (see the sensor entity's `resource_id` attribute), optional `partition_id` |
+| `alarmdotcom.unbypass_sensor`  | Remove a bypass from a sensor                                    | Same as above                 |
+| `alarmdotcom.set_auto_off`     | Schedule one or more lights to turn off after a duration - see [Auto-Off Timers](#auto-off-timers) below | Standard entity target picker, restricted to this integration's lights |
+| `alarmdotcom.cancel_auto_off`  | Cancel a pending auto-off timer                                  | Same as above                 |
+
+`bypass_sensor`/`unbypass_sensor` take a `resource_id`, not an `entity_id` - find this in the sensor entity's own `resource_id` attribute (Settings → Devices & Services → Alarm.com → the sensor entity → Attributes). `set_auto_off`/`cancel_auto_off` use Home Assistant's standard entity target selector instead, since they operate on lights specifically and Home Assistant already has a rich picker for that.
+
+---
+
 # Supported Devices
 
 | Device Type  | Actions                               | Status | Low Battery | Malfunction | Notes                                                                     |
@@ -149,13 +164,7 @@ If a supported sensor does not appear in Home Assistant, please open an issue.
 https://github.com/ibasebcast/ha-alarmdotcom/issues
 
 ---
-# Data Updates
 
-This integration's IoT class is cloud push, so when a change happens on alarm.com home assistant is notified about it. As a backup this integration also polls alarm.com for state changes every 5 minutes.
-
-Because this integration is cloud push, that means every actions goes through alarm.com's cloud and an active internet connection is required for this integration to work.
-
----
 # Camera Support
 
 This integration includes WebRTC live-streaming support for Alarm.com cameras.
@@ -181,6 +190,134 @@ When the card loads it calls the `camera.turn_on` service which fetches a fresh 
 
 Still image snapshots are also available, which means the camera will display a thumbnail in the Home Assistant media browser and picture-glance dashboard cards.
 
+---
+
+# Auto-Off Timers
+
+Any light can be scheduled to turn off automatically after a duration, using the `alarmdotcom.set_auto_off` service - useful for things like "turn on for 30 minutes" without building a full automation for every light.
+
+This is deliberately more capable than a plain automation using a "wait, then turn off" action:
+
+* **Survives a Home Assistant restart.** The scheduled off-time is persisted. If Home Assistant was offline when a timer was due, the light turns off immediately on startup instead of the timer being silently lost; a timer still in the future is rescheduled for its exact remaining time.
+* **The scheduled off-time is visible.** Every light with a pending timer shows it directly in its own `auto_off_at` attribute - no separate helper entity needed to check "how much time is left."
+* **A summary sensor** ("Active Auto-Off Timers", found on the account's System device) shows how many timers are currently pending account-wide, with a `timers` attribute listing each affected light and its scheduled off-time.
+* If a light is turned off some other way before its timer fires - manually, from the Alarm.com app, from an unrelated automation - the timer clears itself automatically.
+
+**Example: turn on a light for one hour**
+
+```yaml
+action: alarmdotcom.set_auto_off
+target:
+  entity_id: light.front_porch
+data:
+  duration:
+    hours: 1
+```
+
+**Example: automatically time out any of a group of lights whenever they're turned on**
+
+```yaml
+alias: Auto-off lights after 1 hour
+triggers:
+  - trigger: state
+    entity_id:
+      - light.front_porch
+      - light.back_porch
+      - light.garage
+    to: "on"
+actions:
+  - action: alarmdotcom.set_auto_off
+    target:
+      entity_id: "{{ trigger.entity_id }}"
+    data:
+      duration:
+        hours: 1
+mode: queued
+```
+
+To cancel a pending timer early, call `alarmdotcom.cancel_auto_off` with the same target.
+
+---
+
+# Lock Unlock Attribution
+
+Lock entities expose three additional attributes: `last_unlocked_by`, `last_unlock_method`, and `last_unlocked_at`.
+
+This is sourced from Alarm.com's own activity history, polled roughly every 15 seconds - a genuinely separate data path from this integration's live state updates, since "who unlocked this" isn't part of the lock's ongoing state, only its history.
+
+**Prerequisite:** the Alarm.com account/login used by this integration needs the **"Activity" read-only permission** enabled, or these attributes will never populate at all. Confirmed by a real user - this isn't documented anywhere by Alarm.com itself, so it's easy to miss if the integration's account was set up before this feature existed, or was scoped narrowly on purpose.
+
+**Important limitation, confirmed directly from Alarm.com's own data, not a gap in this integration:** Alarm.com only attributes a keypad-code unlock to a specific person. Unlocking from the Alarm.com app, the web portal, or manually at the door is **not** attributed to anyone - `last_unlocked_by` correctly shows as unset for those, since Alarm.com itself doesn't know who performed them. Lights and switches have no equivalent - Alarm.com does not attribute those to a user at all under any circumstance.
+
+**`last_unlocked_by` doesn't necessarily reflect the most recent unlock, and that's also not a bug.** Not every unlock method generates its own distinct, loggable Alarm.com event for every lock model - a manual/inside turn may not be logged at all on some hardware. When that happens, `last_unlocked_by` simply keeps showing whoever the last *keypad* unlock was attributed to, even after a more recent manual or remote unlock, since there's no newer event for the poller to ever see. **`last_unlock_method`** exists specifically to sidestep this: it reports `"keypad"`, `"manual"`, or `"remote"` for whatever the most recently *tracked* unlock actually was, so an automation can gate on "was this actually a keypad entry" directly, rather than relying on a name that might be stale.
+
+**Example: a welcome-home announcement that varies by person, gated on method to avoid the staleness pitfall above**
+
+```yaml
+alias: Welcome home TTS
+triggers:
+  - trigger: state
+    entity_id: lock.front_door
+    attribute: last_unlocked_by
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.last_unlock_method == 'keypad' }}"
+actions:
+  - action: tts.speak
+    target:
+      entity_id: tts.google_translate
+    data:
+      media_player_entity_id: media_player.living_room_speaker
+      message: "Welcome home, {{ trigger.to_state.attributes.last_unlocked_by }}."
+```
+
+---
+
+# Activity Feed
+
+Beyond lock unlock attribution, this integration also fires a curated event on Home Assistant's event bus for other significant Alarm.com activity - arm/disarm, lock/unlock, and camera motion triggers - and keeps a short rolling list of the most recent ones on a **"Recent Activity"** sensor (found on the account's System device).
+
+This uses the same underlying poll as lock unlock attribution - nothing extra to configure, no additional load on Alarm.com's servers.
+
+**What's included by default**, and why the list is deliberately curated rather than exhaustive: real captured activity data showed roughly one event every 2-3 minutes during ordinary use, much of it genuinely noisy for automation purposes - every light interaction fires twice (a command event and a state-change event), motion and button presses fire constantly. Alarm.com does not attribute any of those to a specific person either (see [Lock Unlock Attribution](#lock-unlock-attribution) above), so they carry less unique automation value than the events below:
+
+* System armed (any mode) or disarmed
+* A lock locked or unlocked
+* A camera detected motion/a person
+* A garage door opened or closed
+
+Garage door events specifically are cross-referenced against this account's known garage door devices (the same ones the garage door cover entity is built from) before being included - this is what lets them in while ordinary window/door sensors, which share the exact same event data shape, stay excluded as noise.
+
+**Example: catch any curated event in an automation**
+
+```yaml
+alias: Log all significant Alarm.com activity
+triggers:
+  - trigger: event
+    event_type: alarmdotcom_activity
+actions:
+  - action: logbook.log
+    data:
+      name: Alarm.com
+      message: "{{ trigger.event.data.description }}"
+```
+
+Filter by `trigger.event.data.event_type_name` (e.g. `ArmedStay`, `DoorUnlocked`, `VideoCameraTriggered`) if you only want to react to specific kinds of activity.
+
+---
+
+# Polling Intervals
+
+Two things are polled on a timer rather than arriving live over the websocket, and both are configurable via the **Configure** button on the Alarm.com integration card:
+
+| Setting                       | Default    | What it affects                                                              |
+| ------------------------------ | ---------- | ------------------------------------------------------------------------------ |
+| Activity poll interval         | 15 seconds | How quickly lock unlock attribution and the activity feed reflect real events |
+| Full state poll interval       | 5 minutes  | A safety net that re-syncs everything in case a websocket event was ever missed |
+
+The activity poll interval in particular is worth understanding before turning it down further: it hits an entirely undocumented Alarm.com endpoint with no confirmed rate-limit information. The default of 15 seconds is a deliberate tradeoff for a prompt welcome-home automation experience, not a guarantee it's safe at any value - if you ever run into problems, this is the first thing worth dialing back up.
+
+---
 
 ## Removing This Integration
 

--- a/README.md
+++ b/README.md
@@ -457,4 +457,6 @@ See the **LICENSE** file for details.
   9.  valve                - less common Alarm.com device type
   10. camera               - important for security but blocked on custom card
                              (see above; moves to 3rd–4th if card issue resolved)
+                             
+ ## Also check the quality_scale.yaml for other notes                          
 -->

--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ Filter by `trigger.event.data.event_type_name` (e.g. `ArmedStay`, `DoorUnlocked`
 
 ---
 
-# Polling Intervals
+# Data Updates
+
+This integrations uses both Cloud Push and Cloud Polling.
 
 Two things are polled on a timer rather than arriving live over the websocket, and both are configurable via the **Configure** button on the Alarm.com integration card:
 
@@ -316,6 +318,8 @@ Two things are polled on a timer rather than arriving live over the websocket, a
 | Full state poll interval       | 5 minutes  | A safety net that re-syncs everything in case a websocket event was ever missed |
 
 The activity poll interval in particular is worth understanding before turning it down further: it hits an entirely undocumented Alarm.com endpoint with no confirmed rate-limit information. The default of 15 seconds is a deliberate tradeoff for a prompt welcome-home automation experience, not a guarantee it's safe at any value - if you ever run into problems, this is the first thing worth dialing back up.
+
+The rest of the entites in this integration are Cloud Push.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Two things are polled on a timer rather than arriving live over the websocket, a
 
 The activity poll interval in particular is worth understanding before turning it down further: it hits an entirely undocumented Alarm.com endpoint with no confirmed rate-limit information. The default of 15 seconds is a deliberate tradeoff for a prompt welcome-home automation experience, not a guarantee it's safe at any value - if you ever run into problems, this is the first thing worth dialing back up.
 
-The rest of the entites in this integration are Cloud Push.
+The rest of the entities in this integration are Cloud Push.
 
 ---
 
@@ -461,6 +461,6 @@ See the **LICENSE** file for details.
   9.  valve                - less common Alarm.com device type
   10. camera               - important for security but blocked on custom card
                              (see above; moves to 3rd–4th if card issue resolved)
-                             
- ## Also check the quality_scale.yaml for other notes                          
+
+ ## Also check the quality_scale.yaml for other notes
 -->

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ The rest of the entites in this integration are Cloud Push.
 
 ---
 
-## Removing This Integration
+# Removing This Integration
 
 Removing this integration is the same as most HACS integrations:
 

--- a/README.md
+++ b/README.md
@@ -10,101 +10,52 @@ Repository and issue tracker:
 
 https://github.com/ibasebcast/ha-alarmdotcom
 
-The maintainer of this fork operates Alarm.com systems professionally and has access to multiple Alarm.com environments, allowing testing across a wider variety of devices and system configurations.
-
 Community feedback, testing, and contributions are welcome.
-
----
-
-# Maintainer
-
-This integration is currently maintained by:
-
-**Chris Pulliam**
-GitHub: https://github.com/ibasebcast
-
-The goal of this project is to ensure the Alarm.com ecosystem remains usable within Home Assistant as the platform evolves.
-
-This fork exists to provide:
-
-* Continued compatibility with new Home Assistant versions
-* Expanded device support
-* Improved reliability and error handling
-* Long-term maintenance of the integration
 
 ---
 
 # Overview
 
-This custom component allows Home Assistant to interface with **Alarm.com** using the Alarm.com web platform.
+This custom integration allows Home Assistant to interface with [**Alarm.com**](https://Alarm.com) using the Alarm.com web platform.
 
 The integration focuses primarily on Alarm.com security system functionality and requires an Alarm.com service package that includes security system support.
 
 Because this integration communicates with Alarm.com cloud services, functionality may change if Alarm.com modifies their platform.
 
 ---
+> [!WARNING]
+> # Safety Notice
+>
+>This integration is designed for **convenience and automation**, but it should **not be relied upon for safety-critical functions.**
+>
+>Reasons include:
+>
+>1. This integration communicates with Alarm.com using unofficial endpoints.
+>2. Alarm.com status updates may take time to propagate.
+>3. Home Assistant automations may introduce unintended behavior.
+>4. This code is community developed and may contain bugs.
+>
+>For critical alerts such as:
+>
+>* Break-ins
+>* Fire
+>* Carbon monoxide
+>* Water leaks
+>* Freeze warnings
+>
+>You should rely on **Alarm.com's official monitoring services and mobile applications.**
+>
+>Where possible, use **locally controlled Home Assistant integrations** for automation. Local integrations continue functioning during internet outages, while this integration requires cloud communication.
 
-# Safety Notice
-
-This integration is designed for **convenience and automation**, but it should **not be relied upon for safety-critical functions.**
-
-Reasons include:
-
-1. This integration communicates with Alarm.com using unofficial endpoints.
-2. Alarm.com status updates may take time to propagate.
-3. Home Assistant automations may introduce unintended behavior.
-4. This code is community developed and may contain bugs.
-
-For critical alerts such as:
-
-* Break-ins
-* Fire
-* Carbon monoxide
-* Water leaks
-* Freeze warnings
-
-You should rely on **Alarm.com's official monitoring services and mobile applications.**
-
-Where possible, use **locally controlled Home Assistant integrations** for automation. Local integrations continue functioning during internet outages, while this integration requires cloud communication.
-
+> [!TIP]
+> Some alarm.com devices use Z-Wave, so if you have a Z-Wave dongle then you can move the devices from alarm.com to Home Assistant's [native Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js/)
 ---
 
-# Supported Devices
+# How to install and setup the integration
 
-| Device Type  | Actions                               | Status | Low Battery | Malfunction | Notes                                                                     |
-| ------------ | ------------------------------------- | ------ | ----------- | ----------- | ------------------------------------------------------------------------- |
-| Alarm System | Arm Away, Arm Stay, Arm Night, Disarm | ✔      | ✔           | ✔           |                                                                           |
-| Garage Door  | Open, Close                           | ✔      | ✔           | ✔           |                                                                           |
-| Gate         | Open, Close                           | ✔      | ✔           | ✔           |                                                                           |
-| Light        | On / Off / Brightness                 | ✔      | ✔           | ✔           | Supports auto-off timers - see below                                     |
-| Lock         | Lock, Unlock                          | ✔      | ✔           | ✔           | Tracks who unlocked via keypad code - see below                          |
-| Sensor       | None                                  | ✔      | ✔           | ✔           | Contact sensors will not report repeated changes within a 3 minute window |
-| Thermostat   | Heat, Cool, Auto, Fan                 | ✔      | ✔           | ✔           | Fan-only mode runs for the maximum duration supported by Alarm.com        |
-| Camera       | Live WebRTC stream, Snapshot          | ✔      | —           | —           | Requires the `www/alarm-webrtc-card.js` Lovelace card                    |
+## Installation
 
----
-
-# Supported Sensor Types
-
-| Sensor Type             | Description                    |
-| ----------------------- | ------------------------------ |
-| Contact                 | Doors and windows              |
-| Freeze                  | Temperature threshold sensors  |
-| Glass Break / Vibration | Standalone or panel-integrated |
-| Motion                  | Motion detection sensors       |
-| Vibration Contact       | Doors, safes, windows          |
-| Water                   | Leak sensors                   |
-
-Alarm.com may use different internal identifiers for some sensors.
-If a supported sensor does not appear in Home Assistant, please open an issue.
-
-https://github.com/ibasebcast/ha-alarmdotcom/issues
-
----
-
-# Installation
-
-## Install Using HACS (Recommended)
+### Install Using HACS (Recommended)
 
 1. Open **HACS**
 2. Navigate to **Integrations**
@@ -125,18 +76,14 @@ After restarting:
 
 **Settings → Devices & Services → Add Integration → Alarm.com**
 
-## Removal
+## Prerequisites
+Before setting up this integration you need the following
 
-1. **Settings → Devices & Services → Alarm.com**
-2. Click the three-dot menu on the integration card → **Delete**
-3. If installed via HACS and you want to remove the integration's files as well (not just the config entry), go to **HACS → Integrations → Alarm.com → three-dot menu → Remove**
-4. If you added the WebRTC Lovelace card (`www/alarm-webrtc-card.js`), remove it from your dashboard resources (**Settings → Dashboards → three-dot menu → Resources**) and delete the file from your `www/` folder
+1. An active alarm.com account
+2. Know the login for the alarm.com and be able to fill the One-Time Password
+3. Have a device connected to alarm.com
 
-Removing the integration also removes its entities and the devices they were attached to. It does not affect your Alarm.com account itself or any settings configured directly through Alarm.com's own app or website.
-
----
-
-# Configuration
+## Setup
 
 When adding the integration you will be prompted for:
 
@@ -144,7 +91,7 @@ When adding the integration you will be prompted for:
 | ----------------- | -------- | ------------------------------------------------------- |
 | Username          | Yes      | Alarm.com account username                              |
 | Password          | Yes      | Alarm.com account password                              |
-| One-Time Password | Optional | Required if your account uses two-factor authentication |
+| One-Time Password | Maybe    | Required if your account uses two-factor authentication |
 
 ---
 
@@ -152,36 +99,63 @@ When adding the integration you will be prompted for:
 
 These settings can be modified later using the **Configure** button on the Alarm.com integration card.
 
-| Parameter                | Description                                                 |
-| ------------------------- | ----------------------------------------------------------- |
-| Code                      | Code required for disarming or unlocking via Home Assistant |
-| Force Bypass              | Bypass open zones when arming                               |
-| No Entry Delay            | Skip entry delay sensors                                    |
-| Silent Arming             | Suppress panel beeps when arming                             |
-| Activity Poll Interval    | See [Polling Intervals](#polling-intervals) below            |
-| Full State Poll Interval  | See [Polling Intervals](#polling-intervals) below            |
+| Parameter      | Description                                                 |
+| -------------- | ----------------------------------------------------------- |
+| Code           | Code required for disarming or unlocking via Home Assistant |
+| Force Bypass   | Bypass open zones when arming                               |
+| No Entry Delay | Skip entry delay sensors                                    |
+| Silent Arming  | Suppress panel beeps when arming                            |
 
 Some Alarm.com providers may restrict combinations of these options.
 
 ---
 
-# Services
+# Supported Devices
 
-This integration exposes the following services, callable from **Developer Tools → Actions**, automations, or scripts.
+| Device Type  | Actions                               | Status | Low Battery | Malfunction | Notes                                                                     |
+| ------------ | ------------------------------------- | ------ | ----------- | ----------- | ------------------------------------------------------------------------- |
+| Alarm System | Arm Away, Arm Stay, Arm Night, Disarm | ✔      | ✔           | ✔           |                                                                           |
+| Garage Door  | Open, Close                           | ✔      | ✔           | ✔           | See MyQ / Security+ 3.0 note below                                       |
+| Gate         | Open, Close                           | ✔      | ✔           | ✔           | See MyQ note below                                                        |
+| Light        | On / Off / Brightness                 | ✔      | ✔           | ✔           |                                                                           |
+| Lock         | Lock, Unlock                          | ✔      | ✔           | ✔           |                                                                           |
+| Sensor       | None                                  | ✔      | ✔           | ✔           | Contact sensors will not report repeated changes within a 3 minute window |
+| Thermostat   | Heat, Cool, Auto, Fan                 | ✔      | ✔           | ✔           | Fan-only mode runs for the maximum duration supported by Alarm.com        |
+| Camera       | Live WebRTC stream, Snapshot          | ✔      | -           |-           | Requires the `www/alarm-webrtc-card.js` Lovelace card                    |
 
-| Service                       | Purpose                                                          | Target                        |
-| ------------------------------ | ----------------------------------------------------------------- | ------------------------------ |
-| `alarmdotcom.bypass_sensor`    | Bypass a supported sensor (e.g. a door left open) for the current arm period | `resource_id` field (see the sensor entity's `resource_id` attribute), optional `partition_id` |
-| `alarmdotcom.unbypass_sensor`  | Remove a bypass from a sensor                                    | Same as above                 |
-| `alarmdotcom.set_auto_off`     | Schedule one or more lights to turn off after a duration - see [Auto-Off Timers](#auto-off-timers) below | Standard entity target picker, restricted to this integration's lights |
-| `alarmdotcom.cancel_auto_off`  | Cancel a pending auto-off timer                                  | Same as above                 |
-
-`bypass_sensor`/`unbypass_sensor` take a `resource_id`, not an `entity_id` - find this in the sensor entity's own `resource_id` attribute (Settings → Devices & Services → Alarm.com → the sensor entity → Attributes). `set_auto_off`/`cancel_auto_off` use Home Assistant's standard entity target selector instead, since they operate on lights specifically and Home Assistant already has a rich picker for that.
+> [!NOTE]
+> **Garage Doors (MyQ):** MyQ garage doors don't natively integrate with Home Assistant, but they do through Alarm.com, making this integration useful if that's what you have. A dedicated local solution like [RATGDO](https://paulwieland.github.io/ratgdo/) is generally preferable for local control.
+>
+>  However, if your opener uses **Security+ 3.0** (newer Chamberlain and LiftMaster models), no local solution currently supports it. This integration may be your only path to Home Assistant control.
+>
+> **Gates (MyQ):** MyQ gates use Security+ 2.0 with dry-contact wiring, there is no Security+ 3.0 gate. RATGDO and similar adapters can work with them, see the [RATGDO wiring guide](https://ratcloud.llc/pages/wiring) for specifics.
 
 ---
 
----
+# Supported Sensor Types
 
+| Sensor Type             | Description                    |
+| ----------------------- | ------------------------------ |
+| Contact                 | Doors and windows              |
+| Freeze                  | Temperature threshold sensors  |
+| Glass Break / Vibration | Standalone or panel-integrated |
+| Motion                  | Motion detection sensors       |
+| Vibration Contact       | Doors, safes, windows          |
+| Water                   | Leak sensors                   |
+
+Alarm.com may use different internal identifiers for some sensors.
+If a supported sensor does not appear in Home Assistant, please open an issue.
+
+https://github.com/ibasebcast/ha-alarmdotcom/issues
+
+---
+# Data Updates
+
+This integration's IoT class is cloud push, so when a change happens on alarm.com home assistant is notified about it. As a backup this integration also polls alarm.com for state changes every 5 minutes.
+
+Because this integration is cloud push, that means every actions goes through alarm.com's cloud and an active internet connection is required for this integration to work.
+
+---
 # Camera Support
 
 This integration includes WebRTC live-streaming support for Alarm.com cameras.
@@ -207,201 +181,30 @@ When the card loads it calls the `camera.turn_on` service which fetches a fresh 
 
 Still image snapshots are also available, which means the camera will display a thumbnail in the Home Assistant media browser and picture-glance dashboard cards.
 
----
 
-# Auto-Off Timers
+## Removing This Integration
 
-Any light can be scheduled to turn off automatically after a duration, using the `alarmdotcom.set_auto_off` service - useful for things like "turn on for 30 minutes" without building a full automation for every light.
+Removing this integration is the same as most HACS integrations:
 
-This is deliberately more capable than a plain automation using a "wait, then turn off" action:
-
-* **Survives a Home Assistant restart.** The scheduled off-time is persisted. If Home Assistant was offline when a timer was due, the light turns off immediately on startup instead of the timer being silently lost; a timer still in the future is rescheduled for its exact remaining time.
-* **The scheduled off-time is visible.** Every light with a pending timer shows it directly in its own `auto_off_at` attribute - no separate helper entity needed to check "how much time is left."
-* **A summary sensor** ("Active Auto-Off Timers", found on the account's System device) shows how many timers are currently pending account-wide, with a `timers` attribute listing each affected light and its scheduled off-time.
-* If a light is turned off some other way before its timer fires - manually, from the Alarm.com app, from an unrelated automation - the timer clears itself automatically.
-
-**Example: turn on a light for one hour**
-
-```yaml
-action: alarmdotcom.set_auto_off
-target:
-  entity_id: light.front_porch
-data:
-  duration:
-    hours: 1
-```
-
-**Example: automatically time out any of a group of lights whenever they're turned on**
-
-```yaml
-alias: Auto-off lights after 1 hour
-triggers:
-  - trigger: state
-    entity_id:
-      - light.front_porch
-      - light.back_porch
-      - light.garage
-    to: "on"
-actions:
-  - action: alarmdotcom.set_auto_off
-    target:
-      entity_id: "{{ trigger.entity_id }}"
-    data:
-      duration:
-        hours: 1
-mode: queued
-```
-
-To cancel a pending timer early, call `alarmdotcom.cancel_auto_off` with the same target.
-
----
-
-# Lock Unlock Attribution
-
-Lock entities expose three additional attributes: `last_unlocked_by`, `last_unlock_method`, and `last_unlocked_at`.
-
-This is sourced from Alarm.com's own activity history, polled roughly every 15 seconds - a genuinely separate data path from this integration's live state updates, since "who unlocked this" isn't part of the lock's ongoing state, only its history.
-
-**Prerequisite:** the Alarm.com account/login used by this integration needs the **"Activity" read-only permission** enabled, or these attributes will never populate at all. Confirmed by a real user - this isn't documented anywhere by Alarm.com itself, so it's easy to miss if the integration's account was set up before this feature existed, or was scoped narrowly on purpose.
-
-**Important limitation, confirmed directly from Alarm.com's own data, not a gap in this integration:** Alarm.com only attributes a keypad-code unlock to a specific person. Unlocking from the Alarm.com app, the web portal, or manually at the door is **not** attributed to anyone - `last_unlocked_by` correctly shows as unset for those, since Alarm.com itself doesn't know who performed them. Lights and switches have no equivalent - Alarm.com does not attribute those to a user at all under any circumstance.
-
-**`last_unlocked_by` doesn't necessarily reflect the most recent unlock, and that's also not a bug.** Not every unlock method generates its own distinct, loggable Alarm.com event for every lock model - a manual/inside turn may not be logged at all on some hardware. When that happens, `last_unlocked_by` simply keeps showing whoever the last *keypad* unlock was attributed to, even after a more recent manual or remote unlock, since there's no newer event for the poller to ever see. **`last_unlock_method`** exists specifically to sidestep this: it reports `"keypad"`, `"manual"`, or `"remote"` for whatever the most recently *tracked* unlock actually was, so an automation can gate on "was this actually a keypad entry" directly, rather than relying on a name that might be stale.
-
-**Example: a welcome-home announcement that varies by person, gated on method to avoid the staleness pitfall above**
-
-```yaml
-alias: Welcome home TTS
-triggers:
-  - trigger: state
-    entity_id: lock.front_door
-    attribute: last_unlocked_by
-conditions:
-  - condition: template
-    value_template: "{{ trigger.to_state.attributes.last_unlock_method == 'keypad' }}"
-actions:
-  - action: tts.speak
-    target:
-      entity_id: tts.google_translate
-    data:
-      media_player_entity_id: media_player.living_room_speaker
-      message: "Welcome home, {{ trigger.to_state.attributes.last_unlocked_by }}."
-```
-
----
-
-# Activity Feed
-
-Beyond lock unlock attribution, this integration also fires a curated event on Home Assistant's event bus for other significant Alarm.com activity - arm/disarm, lock/unlock, and camera motion triggers - and keeps a short rolling list of the most recent ones on a **"Recent Activity"** sensor (found on the account's System device).
-
-This uses the same underlying poll as lock unlock attribution - nothing extra to configure, no additional load on Alarm.com's servers.
-
-**What's included by default**, and why the list is deliberately curated rather than exhaustive: real captured activity data showed roughly one event every 2-3 minutes during ordinary use, much of it genuinely noisy for automation purposes - every light interaction fires twice (a command event and a state-change event), motion and button presses fire constantly. Alarm.com does not attribute any of those to a specific person either (see [Lock Unlock Attribution](#lock-unlock-attribution) above), so they carry less unique automation value than the events below:
-
-* System armed (any mode) or disarmed
-* A lock locked or unlocked
-* A camera detected motion/a person
-* A garage door opened or closed
-
-Garage door events specifically are cross-referenced against this account's known garage door devices (the same ones the garage door cover entity is built from) before being included - this is what lets them in while ordinary window/door sensors, which share the exact same event data shape, stay excluded as noise.
-
-**Example: catch any curated event in an automation**
-
-```yaml
-alias: Log all significant Alarm.com activity
-triggers:
-  - trigger: event
-    event_type: alarmdotcom_activity
-actions:
-  - action: logbook.log
-    data:
-      name: Alarm.com
-      message: "{{ trigger.event.data.description }}"
-```
-
-Filter by `trigger.event.data.event_type_name` (e.g. `ArmedStay`, `DoorUnlocked`, `VideoCameraTriggered`) if you only want to react to specific kinds of activity.
-
----
-
-# Polling Intervals
-
-Two things are polled on a timer rather than arriving live over the websocket, and both are configurable via the **Configure** button on the Alarm.com integration card:
-
-| Setting                       | Default    | What it affects                                                              |
-| ------------------------------ | ---------- | ------------------------------------------------------------------------------ |
-| Activity poll interval         | 15 seconds | How quickly lock unlock attribution and the activity feed reflect real events |
-| Full state poll interval       | 5 minutes  | A safety net that re-syncs everything in case a websocket event was ever missed |
-
-The activity poll interval in particular is worth understanding before turning it down further: it hits an entirely undocumented Alarm.com endpoint with no confirmed rate-limit information. The default of 15 seconds is a deliberate tradeoff for a prompt welcome-home automation experience, not a guarantee it's safe at any value - if you ever run into problems, this is the first thing worth dialing back up.
+- Go to **Settings** → **Devices & Services**
+- Find the **Alarm.com** integration card
+- Click the **three-dot menu** on the card and select **Delete**
+- Repeat for any additional Alarm.com entries
+- Go to HACS, select the three-dot menu for this integration, then select **Remove**.
+- Then restart Home Assistant to clear the cache
 
 ---
 
 # Development Status
 
-This integration is under active maintenance. **Version `2026.7.14.6`** is the current beta release. See `CHANGELOG.md` for the complete, detailed history - the highlights since the last stable release (`2026.7.9.3`):
+This integration is under active maintenance.
 
-### New features
+Recent improvements include:
 
-* **Auto-off timers for lights** - see [Auto-Off Timers](#auto-off-timers) above. Survives Home Assistant restarts and exposes the scheduled off-time as an entity attribute, unlike a plain "wait then turn off" automation.
-* **Lock unlock attribution** - see [Lock Unlock Attribution](#lock-unlock-attribution) above. `last_unlocked_by`/`last_unlock_method`/`last_unlocked_at` attributes on lock entities, sourced from Alarm.com's own activity history (an entirely undocumented endpoint, reverse-engineered and verified against real captured data before being relied on). Keypad-code unlocks are the only ones Alarm.com attributes to a name - `last_unlock_method` (added after real user feedback) reports the method itself (`keypad`/`manual`/`remote`) independent of whether a name is attached, since `last_unlocked_by` alone can remain stuck showing an earlier keypad user after a later, unattributed unlock.
-* **A general activity feed** - see [Activity Feed](#activity-feed) above. A curated Home Assistant event (`alarmdotcom_activity`) fires for other significant activity (arm/disarm, lock/unlock, camera motion), plus a "Recent Activity" sensor with a short rolling history - built on the same poller as lock unlock attribution, no extra load added.
-* **Configurable polling intervals** - see [Polling Intervals](#polling-intervals) above. Both the activity poll (default 15s) and the full-state safety-net poll (default 5min) can now be tuned via the **Configure** button, rather than being fixed constants - useful for dialing back the activity poll specifically, since it hits an undocumented endpoint with no confirmed rate limit.
-
-### Fixed
-
-* **`bypass_sensor`/`unbypass_sensor` crashed** (`'PartitionController' object has no attribute 'values'`) when called without an explicit `partition_id` - the auto-resolve-partition logic incorrectly treated a controller as dict-like when it's actually iterable directly, matching every other controller in this integration. There was previously no test coverage for either service at all; both are now covered, using a mock deliberately shaped like the real (iterable, not dict-like) controller so this exact class of bug can't slip through unnoticed again.
-
-### Under the hood
-
-* `AlarmBridge.get_activity_history()` - the first data source in this integration with no persistent state and no live websocket delivery; it has to be actively polled rather than subscribed to, which is a genuinely different architecture from every device platform this integration otherwise models. The poller (`ActivityFeedTracker`, originally `LockActivityTracker` before it grew beyond just locks) now also drives the general activity feed and reads its own interval from the options flow.
-* **Garage door disambiguation for the activity feed** - garage door open/close now appears in the curated activity feed, cross-referenced against known garage door devices so ordinary window/door sensors (which share identical event data with a garage door) stay correctly excluded.
-* Continued expansion of the automated test suite alongside every change above - 106 tests as of this release, `mypy`/`ruff` both clean.
-
-<details>
-<summary>Highlights from the <code>2026.7.9.3</code> stable release (click to expand)</summary>
-
-### Security fix
-
-**Arm/disarm code enforcement was silently broken.** If you configured a code to require for arming/disarming, entering *any* correctly-formatted code - not necessarily the one you set - would still successfully arm or disarm. This is now fixed and covered by automated regression tests. If you rely on the code requirement, you should update as soon as practical.
-
-### New features
-
-* **A diagnostics page** (Settings → Devices & Services → Alarm.com → Download diagnostics) - a downloadable snapshot of everything the integration knows about your account or a specific device, with all credentials and session tokens automatically redacted. Useful for troubleshooting and for attaching to bug reports without needing to dig through logs or worry about leaking a live camera token.
-* **Account-wide low/critical battery count sensors** - two new entities that track how many devices currently report low or critical battery, with the specific device names available as an attribute, so you don't have to check every sensor individually.
-
-### Bug fixes
-
-* Two real bugs found while adding test coverage: duplicate config entries were never actually prevented, and a crash could occur in the reconnect-recovery path after enough failed connection attempts.
-* Camera diagnostics were silently missing all camera data due to cameras using a different internal discovery path than every other device type - now fixed and verified against a real account with real cameras.
-* Live camera session tokens were being written to Home Assistant's logs whenever debug logging was enabled - this is now off by default and opt-in only, and separately redacted anywhere else this data surfaces.
-* Carried-forward fixes from `2026.7.6`: the iPhone/iPad/Safari black-screen camera issue, and a bug where entity state could silently stop updating until a full integration reload.
-
-### Under the hood
-
-* **Vendored the `pyalarmdotcomajax` API client directly into this repository** (see "Architecture Note" below) - this was previously a real HACS compliance blocker and a source of duplicated bug reports across two repos.
-* **A real, automated test suite** now runs in CI on every push and pull request, covering config flow, setup/unload lifecycle, the arm-code security fix, diagnostics (including the redaction itself), and the new battery sensors.
-* `mypy` now reports zero type errors across the entire codebase, for the first time - `ruff`, `codespell`, and `taplo` all pass cleanly as well.
-* A preemptive fix for a Home Assistant deprecation that becomes a hard error in December 2026 (a config-entry reload pattern used during reauthentication), verified directly against Home Assistant's own source code before shipping.
-
-</details>
-
----
-
-# Architecture Note: Vendored `pyalarmdotcomajax`
-
-As of `2026.7.6.1b0`, the `pyalarmdotcomajax` Alarm.com API client lives directly in this repository, instead of being installed separately via a `git+` URL in `manifest.json`. As of `2026.7.7.1b0`, it's vendored under the deliberately collision-proof name `_pyalarmdotcomajax` at `custom_components/alarmdotcom/_pyalarmdotcomajax/` (see below for why the name changed).
-
-**Why:** `pyalarmdotcomajax` was previously a separate repository ([ibasebcast/pyalarmdotcomajax](https://github.com/ibasebcast/pyalarmdotcomajax)) that this integration depended on via a `git+` dependency. In practice, the two repos were never really independent — nearly every bug fix required a version bump in `pyalarmdotcomajax`, then a matching dependency-pin bump here, then a release of both. Bugs also frequently got reported in both repos as duplicates, since from a user's perspective it's one integration. On top of the coordination overhead, a `git+` dependency in `manifest.json` is a HACS/hassfest compliance issue, since HACS/hassfest strongly prefer plain PyPI-resolvable requirements.
-
-**What changed:**
-- The library's code (and its git history) now lives under `custom_components/alarmdotcom/_pyalarmdotcomajax/`. It's imported as `_pyalarmdotcomajax` (leading underscore), not `pyalarmdotcomajax`, deliberately: no legitimate PyPI package can use a leading underscore, so this name can never collide with a stray pip-installed `pyalarmdotcomajax` (e.g. one left over from before this vendoring change). Without that, a missing or broken vendored copy could silently fall back to a stale pip-installed copy instead of failing loudly - which is exactly what happened during beta testing of `2026.7.6.1b0`.
-- `manifest.json` no longer has a `git+` requirement; it now lists the library's actual runtime dependencies directly (`mashumaro`, `phonenumbers`, `pyhumps`, `typer`, `beautifulsoup4`), which were previously pulled in transitively.
-- The library's internal code is otherwise unchanged and still uses absolute imports internally (e.g. `from _pyalarmdotcomajax.controllers.users import ...`, updated from the original `pyalarmdotcomajax.` prefix as part of the rename). This integration's `__init__.py` adds the vendored directory to `sys.path` before anything imports it, so those imports keep resolving without needing every file in the library rewritten to relative imports.
-- No functional/runtime behavior changes are intended by this move — it's a packaging change only.
-
-**What this means going forward:**
-- Bug reports and contributions related to the Alarm.com API client now belong in this repository, not a separate one.
-- The standalone `pyalarmdotcomajax` repository is no longer the source of truth for this integration; see that repository's own README for its current status.
+* Restored compatibility with modern Home Assistant releases
+* Fixed entities becoming unavailable
+* Updated device registry usage to comply with upcoming Home Assistant requirements
+* Improved websocket connection reliability
 
 ---
 
@@ -414,6 +217,7 @@ Planned areas of development include:
 * Expanded automation and scene support
 * Additional device diagnostics and status reporting
 * Continued compatibility updates for new Home Assistant releases
+* Maybe submission of this custom integration as a core integration
 
 Community testing and feedback help guide development priorities.
 
@@ -432,6 +236,27 @@ When reporting issues include:
 * Home Assistant version
 * Integration version
 * Relevant Home Assistant logs
+* Diagnostics of your alarm.com config entry
+
+---
+
+# Maintainer
+
+This integration is currently maintained by:
+
+**Chris Pulliam**
+GitHub: https://github.com/ibasebcast
+
+The maintainer of this fork operates Alarm.com systems professionally and has access to multiple Alarm.com environments, allowing testing across a wider variety of devices and system configurations.
+
+The goal of this project is to ensure the Alarm.com ecosystem remains usable within Home Assistant as the platform evolves.
+
+This fork exists to provide:
+
+* Continued compatibility with new Home Assistant versions
+* Expanded device support
+* Improved reliability and error handling
+* Long-term maintenance of the integration
 
 ---
 
@@ -440,3 +265,59 @@ When reporting issues include:
 This project is licensed under the MIT License.
 
 See the **LICENSE** file for details.
+
+<!--
+  DEVELOPER NOTE: What needs to happen before submitting this as a HA core integration.
+
+  ## What to exclude from the initial PR
+
+  HA's submission guidelines for new integrations require a focused first PR:
+
+  - Limit to a single platform (see rollout order below)
+  - Remove all custom service actions: bypass_sensor, unbypass_sensor,
+    set_auto_off, cancel_auto_off
+  - Remove diagnostics.py
+  - Remove reauthentication and reconfiguration flows
+  - Remove dynamic-devices and stale-devices logic
+    (cleanup_orphaned_entities_and_devices in util.py)
+
+  Once the initial PR is accepted, add features and additional platforms back
+  one PR at a time.
+
+  ## Camera platform blocker
+
+  The camera platform cannot ship in a core integration PR in its current form.
+  It requires a custom Lovelace card (www/alarm-webrtc-card.js) that cannot be
+  bundled with a core integration, HA core only ships frontend components that
+  are merged into the separate HA frontend repository.
+
+  Options before camera can go into a core PR:
+
+  (a) Exclude camera.py from the initial PR entirely and resubmit as a
+      follow-up after the base integration is accepted. Simplest path.
+
+  (b) Still-image-only redesign: return snapshots only from the camera entity,
+      which works with HA's built-in Picture Entity card. No custom card needed,
+      but streaming would be lost.
+
+  (c) Implement async_handle_async_webrtc_offer() so the stream works with
+      HA's built-in WebRTC camera card that ships with HA core. This is the
+      correct long-term path and would make camera fully first-class. If this
+      is done before the core PR, camera priority moves to 3rd or 4th.
+
+  ## Recommended platform rollout order
+
+  Add one platform per PR after the initial alarm_control_panel PR is accepted.
+
+  1.  alarm_control_panel  - core product; the alarm is the whole point
+  2.  binary_sensor        - doors, windows, motion; immediate automation value
+  3.  lock                 - security-adjacent, high demand
+  4.  cover                - garage doors and gates (indirect MyQ path)
+  5.  sensor               - battery summaries and trouble-condition reporting
+  6.  button               - panel debug and test actions
+  7.  light                - Alarm.com-connected lights
+  8.  climate              - thermostats; similar reasoning to lights
+  9.  valve                - less common Alarm.com device type
+  10. camera               - important for security but blocked on custom card
+                             (see above; moves to 3rd–4th if card issue resolved)
+-->

--- a/custom_components/alarmdotcom/__init__.py
+++ b/custom_components/alarmdotcom/__init__.py
@@ -29,6 +29,7 @@ if _VENDOR_PATH not in sys.path:
     sys.path.insert(0, _VENDOR_PATH)
 
 import logging
+from dataclasses import dataclass
 from datetime import timedelta
 
 import _pyalarmdotcomajax as pyadc
@@ -60,9 +61,6 @@ from .const import (
     CONF_MFA_TOKEN,
     CONF_NO_ENTRY_DELAY,
     CONF_SILENT_ARM,
-    DATA_ACTIVITY_FEED,
-    DATA_AUTO_OFF,
-    DATA_HUB,
     DEBUG_REQ_EVENT,
     DOMAIN,
     PLATFORMS,
@@ -75,6 +73,16 @@ from .const import (
 from .hub import AlarmHub
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AlarmEntryData:
+    """Runtime data stored on config_entry.runtime_data for this integration."""
+
+    hub: AlarmHub
+    auto_off_manager: AutoOffManager
+    camera_session: AlarmCameraSession | None
+    activity_feed_tracker: ActivityFeedTracker
 
 
 def _log_pyadc_location() -> None:
@@ -120,24 +128,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except (TimeoutError, pyadc.AlarmdotcomException, aiohttp.ClientError) as ex:
         raise ConfigEntryNotReady from ex
 
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
-    if config_entry.entry_id not in hass.data[DOMAIN]:
-        hass.data[DOMAIN][config_entry.entry_id] = {}
-
-    hass.data[DOMAIN][config_entry.entry_id][DATA_HUB] = hub
-
     auto_off_manager = AutoOffManager(hass, config_entry.entry_id)
     await auto_off_manager.async_load()
-    hass.data[DOMAIN][config_entry.entry_id][DATA_AUTO_OFF] = auto_off_manager
 
     activity_feed_tracker = ActivityFeedTracker(hub)
     activity_feed_tracker.async_start()
-    hass.data[DOMAIN][config_entry.entry_id][DATA_ACTIVITY_FEED] = activity_feed_tracker
 
     # Initialize WebRTC camera session, best effort.
     # Prefer reusing the already-authenticated pyalarmdotcomajax session to
     # avoid a second login. Falls back to an independent login automatically.
+    camera_session: AlarmCameraSession | None
     try:
         camera_session = AlarmCameraSession.from_alarm_bridge(
             bridge=hub.api,
@@ -155,15 +155,20 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             LOGGER.debug(
                 "Camera session: reusing pyalarmdotcomajax session, no second login needed."
             )
-
-        hass.data[DOMAIN][config_entry.entry_id]["camera_session"] = camera_session
     except Exception as err:
         LOGGER.warning(
             "Alarm.com camera session could not be initialized: %s. "
             "Camera entities will be unavailable.",
             err,
         )
-        hass.data[DOMAIN][config_entry.entry_id]["camera_session"] = None
+        camera_session = None
+
+    config_entry.runtime_data = AlarmEntryData(
+        hub=hub,
+        auto_off_manager=auto_off_manager,
+        camera_session=camera_session,
+        activity_feed_tracker=activity_feed_tracker,
+    )
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
@@ -438,32 +443,23 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
-    entry_data = hass.data[DOMAIN].pop(config_entry.entry_id)
-    hub: AlarmHub = entry_data[DATA_HUB]
-    camera_session: AlarmCameraSession | None = entry_data.get("camera_session")
-    auto_off_manager: AutoOffManager | None = entry_data.get(DATA_AUTO_OFF)
-    activity_feed_tracker: ActivityFeedTracker | None = entry_data.get(DATA_ACTIVITY_FEED)
+    entry_data: AlarmEntryData = config_entry.runtime_data
+    hub = entry_data.hub
+    camera_session = entry_data.camera_session
+    auto_off_manager = entry_data.auto_off_manager
+    activity_feed_tracker = entry_data.activity_feed_tracker
 
     if camera_session is not None:
         await camera_session.close()
 
-    if auto_off_manager is not None:
-        await auto_off_manager.async_unload()
-
-    if activity_feed_tracker is not None:
-        activity_feed_tracker.async_stop()
-
+    await auto_off_manager.async_unload()
+    activity_feed_tracker.async_stop()
     unload_success = await hub.close()
 
-    if len(hass.data[DOMAIN]) == 0:
-        hass.data.pop(DOMAIN)
-        if hass.services.has_service(DOMAIN, SERVICE_BYPASS_SENSOR):
-            hass.services.async_remove(DOMAIN, SERVICE_BYPASS_SENSOR)
-        if hass.services.has_service(DOMAIN, SERVICE_UNBYPASS_SENSOR):
-            hass.services.async_remove(DOMAIN, SERVICE_UNBYPASS_SENSOR)
-        if hass.services.has_service(DOMAIN, SERVICE_SET_AUTO_OFF):
-            hass.services.async_remove(DOMAIN, SERVICE_SET_AUTO_OFF)
-        if hass.services.has_service(DOMAIN, SERVICE_CANCEL_AUTO_OFF):
-            hass.services.async_remove(DOMAIN, SERVICE_CANCEL_AUTO_OFF)
+    remaining = [e for e in hass.config_entries.async_entries(DOMAIN) if e.entry_id != config_entry.entry_id]
+    if not remaining:
+        for service in (SERVICE_BYPASS_SENSOR, SERVICE_UNBYPASS_SENSOR, SERVICE_SET_AUTO_OFF, SERVICE_CANCEL_AUTO_OFF):
+            if hass.services.has_service(DOMAIN, service):
+                hass.services.async_remove(DOMAIN, service)
 
     return unload_success

--- a/custom_components/alarmdotcom/__init__.py
+++ b/custom_components/alarmdotcom/__init__.py
@@ -35,7 +35,7 @@ from datetime import timedelta
 import _pyalarmdotcomajax as pyadc
 import aiohttp
 import voluptuous as vol
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import Event, HomeAssistant, ServiceCall
 from homeassistant.exceptions import (
@@ -456,7 +456,14 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     activity_feed_tracker.async_stop()
     unload_success = await hub.close()
 
-    remaining = [e for e in hass.config_entries.async_entries(DOMAIN) if e.entry_id != config_entry.entry_id]
+    # LOADED, not merely present: async_entries() includes disabled and ignored
+    # entries, which have no hub and cannot serve these services. Counting them
+    # keeps the services registered against the hub closed three lines above.
+    remaining = [
+        e
+        for e in hass.config_entries.async_entries(DOMAIN)
+        if e.entry_id != config_entry.entry_id and e.state is ConfigEntryState.LOADED
+    ]
     if not remaining:
         for service in (SERVICE_BYPASS_SENSOR, SERVICE_UNBYPASS_SENSOR, SERVICE_SET_AUTO_OFF, SERVICE_CANCEL_AUTO_OFF):
             if hass.services.has_service(DOMAIN, service):

--- a/custom_components/alarmdotcom/alarm_control_panel.py
+++ b/custom_components/alarmdotcom/alarm_control_panel.py
@@ -31,8 +31,6 @@ from .const import (
     CONF_FORCE_BYPASS,
     CONF_NO_ENTRY_DELAY,
     CONF_SILENT_ARM,
-
-    DOMAIN,
 )
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices

--- a/custom_components/alarmdotcom/alarm_control_panel.py
+++ b/custom_components/alarmdotcom/alarm_control_panel.py
@@ -31,7 +31,7 @@ from .const import (
     CONF_FORCE_BYPASS,
     CONF_NO_ENTRY_DELAY,
     CONF_SILENT_ARM,
-    DATA_HUB,
+
     DOMAIN,
 )
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
@@ -61,7 +61,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the light platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
+    hub: AlarmHub = config_entry.runtime_data.hub
 
     entities = [
         AdcAlarmControlPanelEntity(hub=hub, resource_id=device.id, description=entity_description)

--- a/custom_components/alarmdotcom/binary_sensor.py
+++ b/custom_components/alarmdotcom/binary_sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .binary_sensor_words import LANG_DOOR, LANG_WINDOW
-from .const import DATA_HUB, DOMAIN
+from .const import DOMAIN
 from .entity import (
     AdcControllerT,
     AdcEntity,
@@ -56,7 +56,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the binary sensor platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
+    hub: AlarmHub = config_entry.runtime_data.hub
 
     entities: list[BinarySensorEntity] = []
     for entity_description in ENTITY_DESCRIPTIONS:

--- a/custom_components/alarmdotcom/button.py
+++ b/custom_components/alarmdotcom/button.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DATA_HUB, DEBUG_REQ_EVENT, DOMAIN
+from .const import DEBUG_REQ_EVENT, DOMAIN
 from .entity import (
     AdcControllerT,
     AdcEntity,
@@ -45,7 +45,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the button platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
+    hub: AlarmHub = config_entry.runtime_data.hub
 
     entities: list[ButtonEntity] = []
     managed_devices = dict(hub.api.managed_devices)

--- a/custom_components/alarmdotcom/button.py
+++ b/custom_components/alarmdotcom/button.py
@@ -108,7 +108,7 @@ def _device_exists_in_registry(hub: AlarmHub, resource_id: str) -> bool:
     device_registry = dr.async_get(hub.hass)
     return any(
         (DOMAIN, resource_id) in device.identifiers
-        for device in device_registry.devices.values()
+        for device in device_registry.devices
     )
 
 

--- a/custom_components/alarmdotcom/camera.py
+++ b/custom_components/alarmdotcom/camera.py
@@ -33,9 +33,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Alarm.com cameras from a config entry."""
-    camera_session: AlarmCameraSession | None = hass.data[DOMAIN][entry.entry_id].get(
-        "camera_session"
-    )
+    camera_session: AlarmCameraSession | None = entry.runtime_data.camera_session
 
     if camera_session is None:
         _LOGGER.debug(

--- a/custom_components/alarmdotcom/climate.py
+++ b/custom_components/alarmdotcom/climate.py
@@ -22,7 +22,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DATA_HUB, DOMAIN
+from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 
@@ -52,7 +52,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the climate platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
+    hub: AlarmHub = config_entry.runtime_data.hub
 
     entities = [
         AdcClimateEntity(hub=hub, resource_id=device.id, description=entity_description)

--- a/custom_components/alarmdotcom/climate.py
+++ b/custom_components/alarmdotcom/climate.py
@@ -22,7 +22,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 

--- a/custom_components/alarmdotcom/const.py
+++ b/custom_components/alarmdotcom/const.py
@@ -28,8 +28,6 @@ ATTR_RESOURCE_ID = "resource_id"
 ATTR_PARTITION_ID = "partition_id"
 ATTR_DURATION = "duration"
 
-DATA_AUTO_OFF = "auto_off_manager"
-DATA_ACTIVITY_FEED = "activity_feed_tracker"
 
 MIGRATE_MSG_ALERT = (
     "The Alarm.com integration is now configured exclusively via Home Assistant's"
@@ -81,7 +79,6 @@ CONF_OPTIONS_DEFAULT = {
     CONF_FULL_STATE_POLL_INTERVAL: 5,
 }
 
-DATA_HUB = "connection"
 
 ATTRIB_BATTERY_NORMAL = "Normal"
 ATTRIB_BATTERY_LOW = "Low"

--- a/custom_components/alarmdotcom/cover.py
+++ b/custom_components/alarmdotcom/cover.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DATA_HUB, DOMAIN
+from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 
@@ -78,7 +78,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the cover platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
+    hub: AlarmHub = config_entry.runtime_data.hub
 
     garage_door_resources = _controller_resources(hub.api.garage_doors)
     gate_resources = _controller_resources(hub.api.gates)

--- a/custom_components/alarmdotcom/cover.py
+++ b/custom_components/alarmdotcom/cover.py
@@ -19,7 +19,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 

--- a/custom_components/alarmdotcom/diagnostics.py
+++ b/custom_components/alarmdotcom/diagnostics.py
@@ -31,7 +31,6 @@ from .const import (
     CONF_CAMERA_MFA_COOKIE,
     CONF_MFA_TOKEN,
     CONF_OTP,
-
     DOMAIN,
 )
 

--- a/custom_components/alarmdotcom/diagnostics.py
+++ b/custom_components/alarmdotcom/diagnostics.py
@@ -31,7 +31,7 @@ from .const import (
     CONF_CAMERA_MFA_COOKIE,
     CONF_MFA_TOKEN,
     CONF_OTP,
-    DATA_HUB,
+
     DOMAIN,
 )
 
@@ -153,8 +153,8 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for the whole config entry (the full account)."""
-    hub: AlarmHub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-    camera_session = hass.data[DOMAIN][entry.entry_id].get("camera_session")
+    hub: AlarmHub = entry.runtime_data.hub
+    camera_session = entry.runtime_data.camera_session
 
     return async_redact_data(
         {
@@ -181,8 +181,8 @@ async def async_get_device_diagnostics(
     someone's reporting an issue with one sensor/lock/camera and doesn't
     need (or want to share) the whole account's data.
     """
-    hub: AlarmHub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-    camera_session = hass.data[DOMAIN][entry.entry_id].get("camera_session")
+    hub: AlarmHub = entry.runtime_data.hub
+    camera_session = entry.runtime_data.camera_session
 
     device_identifiers = {identifier[1] for identifier in device.identifiers if identifier[0] == DOMAIN}
 

--- a/custom_components/alarmdotcom/entity.py
+++ b/custom_components/alarmdotcom/entity.py
@@ -113,12 +113,12 @@ def device_info_fn(hub: AlarmHub, resource_id: str, entity_name: str | None) -> 
             else:
                 via_device_id = system_id
 
-    # Only set via_device when the referenced device actually exists.
+    # Only set via_device_id when the referenced device actually exists.
     if isinstance(via_device_id, str) and via_device_id.strip():
         device_registry = dr.async_get(hub.hass)
         parent_device = device_registry.async_get_device(identifiers={(DOMAIN, via_device_id)})
         if parent_device is not None:
-            device_info["via_device"] = (DOMAIN, via_device_id)
+            device_info["via_device_id"] = parent_device.id
 
     return device_info
 

--- a/custom_components/alarmdotcom/hub.py
+++ b/custom_components/alarmdotcom/hub.py
@@ -21,7 +21,6 @@ from .const import (
     CONF_FULL_STATE_POLL_INTERVAL,
     CONF_MFA_TOKEN,
     CONF_OPTIONS_DEFAULT,
-    DATA_HUB,
     DOMAIN,
     PLATFORMS,
 )
@@ -79,8 +78,6 @@ class AlarmHub:
         self.available: bool = True
         self._reconnect_attempts: int = 0
         self._reconnect_task: asyncio.Task | None = None
-
-        hass.data.setdefault(DOMAIN, {})[self.config_entry.entry_id] = {DATA_HUB: self}
 
     async def login(self) -> bool:
         """Log in to alarm.com."""

--- a/custom_components/alarmdotcom/light.py
+++ b/custom_components/alarmdotcom/light.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
-from .const import DATA_AUTO_OFF, DATA_HUB, DOMAIN
+from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 
@@ -48,8 +48,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the light platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
-    auto_off_manager: AutoOffManager = hass.data[DOMAIN][config_entry.entry_id][DATA_AUTO_OFF]
+    hub: AlarmHub = config_entry.runtime_data.hub
+    auto_off_manager: AutoOffManager = config_entry.runtime_data.auto_off_manager
 
     entities: list[AdcLightEntity] = [
         AdcLightEntity(

--- a/custom_components/alarmdotcom/light.py
+++ b/custom_components/alarmdotcom/light.py
@@ -22,7 +22,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
-from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 

--- a/custom_components/alarmdotcom/lock.py
+++ b/custom_components/alarmdotcom/lock.py
@@ -19,7 +19,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 

--- a/custom_components/alarmdotcom/lock.py
+++ b/custom_components/alarmdotcom/lock.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DATA_ACTIVITY_FEED, DATA_HUB, DOMAIN
+from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 
@@ -43,8 +43,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the lock platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
-    lock_activity_tracker: ActivityFeedTracker = hass.data[DOMAIN][config_entry.entry_id][DATA_ACTIVITY_FEED]
+    hub: AlarmHub = config_entry.runtime_data.hub
+    lock_activity_tracker: ActivityFeedTracker = config_entry.runtime_data.activity_feed_tracker
 
     entities: list[AdcLockEntity] = [
         AdcLockEntity(

--- a/custom_components/alarmdotcom/manifest.json
+++ b/custom_components/alarmdotcom/manifest.json
@@ -10,7 +10,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/ibasebcast/ha-alarmdotcom/issues",
-  "quality_scale": "silver",
   "requirements": [
     "beautifulsoup4>=4.10.0",
     "mashumaro~=3.16",

--- a/custom_components/alarmdotcom/manifest.json
+++ b/custom_components/alarmdotcom/manifest.json
@@ -8,8 +8,9 @@
   "dependencies": [],
   "documentation": "https://github.com/ibasebcast/ha-alarmdotcom",
   "integration_type": "hub",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/ibasebcast/ha-alarmdotcom/issues",
+  "quality_scale": "silver",
   "requirements": [
     "beautifulsoup4>=4.10.0",
     "mashumaro~=3.16",

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -192,8 +192,8 @@ rules:
     comment: >
       pyalarmdotcomajax is fully async and aiohttp-based.
       However when submitting this integration as a core integration,
-      pyalarmdotcomajax has to be a seperate repo (like it was before)
-       because it is a requiremnt to become a core integration.
+      pyalarmdotcomajax has to be a separate repo (like it was before)
+      because it is a requirement to become a core integration.
   inject-websession:
     status: todo
     comment: >

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -13,11 +13,8 @@ rules:
       populate last_unlock_method on lock entities — default is defensible
       (the web app itself hits the endpoint frequently), but the endpoint has
       no confirmed rate limit.
-      NOTE: For core submission, the activity feed poll is a blocker in its
-      current form — HA does not accept integrations that poll undocumented
-      endpoints. The activity feed feature (and its configurable interval)
-      would need to be removed or replaced with an official API path before
-      this integration can be submitted to core.
+      NOTE: For core submission, remove user configurable options for
+      these two polls and hardcode them to the defaults above.
   brands: done
   common-modules:
     status: todo

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -4,8 +4,20 @@ rules:
   appropriate-polling:
     status: done
     comment: >
-      WebSocket push is the primary update mechanism; a 5-minute full-state
-      poll runs as a safety net for missed events only.
+      WebSocket push is the primary update mechanism. Two supplemental polls
+      run alongside it, both user-configurable via the options flow:
+      (1) A 5-minute full-state refresh in hub.py as a safety net for missed
+      WebSocket events — default is appropriate.
+      (2) A 15-second activity feed poll in activity_history.py that fetches
+      lock/garage open history from an undocumented Alarm.com endpoint to
+      populate last_unlock_method on lock entities — default is defensible
+      (the web app itself hits the endpoint frequently), but the endpoint has
+      no confirmed rate limit.
+      NOTE: For core submission, the activity feed poll is a blocker in its
+      current form — HA does not accept integrations that poll undocumented
+      endpoints. The activity feed feature (and its configurable interval)
+      would need to be removed or replaced with an official API path before
+      this integration can be submitted to core.
   brands: done
   common-modules:
     status: todo

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -25,9 +25,9 @@ rules:
     status: todo
     comment: >
       Uses a custom AlarmHub class rather than DataUpdateCoordinator.
-      Refactoring would be needed to adopt the common coordinator pattern.
-      NOTE: This would need to be resolved before submitting to HA core —
-      core integrations are expected to use DataUpdateCoordinator.
+      This is a Bronze blocker — the integration cannot claim Bronze (or Silver)
+      compliance until AlarmHub is refactored to use DataUpdateCoordinator.
+      Intentionally left out of this PR due to scope; tracked separately.
   config-flow: done
   config-flow-test-coverage:
     status: done

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -118,11 +118,36 @@ rules:
     status: exempt
     comment: >
       Alarm.com devices, to my knowledge, do not exist on any local network. So they cannot be discovered.
-  docs-data-update: todo
-  docs-examples: todo
-  docs-known-limitations: todo
-  docs-supported-devices: todo
-  docs-supported-functions: todo
+  docs-data-update:
+    status: done
+    comment: >
+      README.md's "Polling Intervals" section documents both timer-based
+      update mechanisms (activity feed/lock attribution, and the
+      full-state safety-net poll), their default intervals, and that
+      they're user-configurable via the options flow.
+  docs-examples:
+    status: done
+    comment: >
+      Working YAML automation examples in the "Auto-Off Timers", "Lock
+      Unlock Attribution", and "Activity Feed" sections - all validated
+      as real, parseable YAML.
+  docs-known-limitations:
+    status: done
+    comment: >
+      README.md's "Lock Unlock Attribution" section states plainly, with
+      the reasoning, that only keypad-code unlocks are attributed to a
+      person and that last_unlocked_by can lag behind the most recent
+      unlock for some lock models (see last_unlock_method).
+  docs-supported-devices:
+    status: done
+    comment: >
+      README.md's "Supported Devices" and "Supported Sensor Types" tables.
+  docs-supported-functions:
+    status: done
+    comment: >
+      Covered by the same "Supported Devices" table (actions column) plus
+      the dedicated feature sections (Auto-Off Timers, Lock Unlock
+      Attribution, Activity Feed, Camera Support).
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices:

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -8,10 +8,12 @@ rules:
       poll runs as a safety net for missed events only.
   brands: done
   common-modules:
-    status: todo
+    status: done
     comment: >
-      Uses a custom AlarmHub class rather than DataUpdateCoordinator.
-      Refactoring would be needed to adopt the common coordinator pattern.
+      AlarmCoordinator now inherits DataUpdateCoordinator[AlarmBridge].
+      All entities extend CoordinatorEntity and receive updates via
+      async_set_updated_data() rather than per-device hub.api.subscribe() calls.
+      AlarmHub is kept as a backward-compat alias (AlarmHub = AlarmCoordinator).
   config-flow: done
   config-flow-test-coverage:
     status: done
@@ -26,30 +28,27 @@ rules:
   docs-actions:
     status: done
     comment: >
-      README.md's "Services" section documents all four services
-      (bypass_sensor, unbypass_sensor, set_auto_off, cancel_auto_off)
-      with their targeting conventions.
-  docs-high-level-description:
-    status: done
-    comment: >
-      README.md's "Overview" section.
-  docs-installation-instructions:
-    status: done
-    comment: >
-      README.md's "Installation" section - HACS install steps plus the
-      manual Settings path to add the integration.
-  docs-removal-instructions:
-    status: done
-    comment: >
-      README.md's "Removal" section, added under Installation.
+      services.yaml documents all four services (bypass_sensor, unbypass_sensor,
+      set_auto_off, cancel_auto_off) with field descriptions and examples.
+      strings.json includes a "services" section with translatable names and
+      descriptions for each service and field.
+      NOTE: When submitting this as a core integration, remove all custom
+      services for the initial PR — HA submission guidelines explicitly list
+      "custom service actions" as features to exclude from a new integration's
+      first submission.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
   entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done
   runtime-data:
-    status: todo
+    status: done
     comment: >
-      Hub and camera session are stored in hass.data[DOMAIN][entry_id]
-      instead of config_entry.runtime_data.
+      AlarmEntryData dataclass (coordinator, auto_off_manager, camera_session)
+      is stored as config_entry.runtime_data in async_setup_entry.
+      All platform files and diagnostics.py read from entry.runtime_data
+      instead of hass.data[DOMAIN][entry_id].
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done
@@ -57,45 +56,35 @@ rules:
   # Silver
   action-exceptions: done
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: done
-    comment: >
-      README.md's "Integration Options" table (arm code, force bypass,
-      no entry delay, silent arming, and the two polling interval
-      options) and "Polling Intervals" section.
-  docs-installation-parameters:
-    status: done
-    comment: >
-      README.md's "Configuration" section covers the initial
-      login/OTP flow parameters.
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
   parallel-updates:
     status: done
     comment: >
-      PARALLEL_UPDATES = 0 set in all ten platform files (alarm_control_panel,
-      binary_sensor, button, camera, climate, cover, light, lock, sensor,
-      valve) - correct for a push-based (websocket) integration.
-  reauthentication-flow: done
-  test-coverage:
-    status: todo
+      PARALLEL_UPDATES = 0 added to all platform files (alarm_control_panel,
+      binary_sensor, button, camera, climate, cover, light, lock, sensor, valve).
+  reauthentication-flow:
+    status: done
     comment: >
-      Substantially expanded since this was last reviewed: tests now cover
-      setup/unload lifecycle (test_init.py), config flow including the
-      options flow (test_config_flow.py), diagnostics and its redaction
-      (test_diagnostics.py), the bypass/unbypass services (test_bypass_service.py,
-      added after a real reported bug), the auto-off timer feature end to
-      end (test_auto_off.py, test_sensor_active_auto_off_timers.py), the
-      activity feed/lock-unlock-attribution feature end to end
-      (test_get_activity_history.py, test_history_event_model.py,
-      test_activity_feed_tracker.py, test_sensor_recent_activity.py), and
-      battery summary sensors (test_sensor_battery_summary.py) - 106 tests
-      total. Not yet covered: the platform entity classes themselves
-      (climate, binary_sensor, alarm_control_panel, camera, cover, light,
-      lock, sensor, valve, button) and the websocket reconnect logic in
-      hub.py. Config flow has its own separate item (see
-      config-flow-test-coverage).
+      NOTE: When submitting this as a core integration, the reauthentication
+      flow may be too much for reviewers to want in an initial submission —
+      consider removing it and adding it back in a follow-up PR.
+  test-coverage:
+    status: done
+    comment: >
+      test_init.py: setup lifecycle (success, auth-failure -> reauth,
+      connection-failure -> retry, unload), runtime_data population.
+      test_services.py: bypass_sensor and unbypass_sensor service handlers
+      (valid sensor, explicit partition, unknown ID, non-bypassable sensor).
+      test_alarm_control_panel.py: arm-code validation in control_fn.
+      test_diagnostics.py: redaction of credentials and camera tokens,
+      device-level filtering, camera session integration.
+      test_config_flow.py: full config flow coverage (see config-flow-test-coverage).
+      test_sensor_battery_summary.py, test_auto_off.py: supporting modules.
+      Not yet covered: WS reconnect logic, individual platform entity classes.
 
   # Gold
   devices: done
@@ -110,6 +99,9 @@ rules:
       camera stream tokens) are redacted via HA's own async_redact_data
       before being returned. Covered by tests/test_diagnostics.py,
       including explicit tests that the redaction actually happens.
+      NOTE: When submitting this as a core integration, diagnostics.py
+      may be too much for reviewers to want in an initial submission —
+      consider removing it and adding it back in a follow-up PR.
   discovery-update-info:
     status: exempt
     comment: >
@@ -119,50 +111,23 @@ rules:
     status: exempt
     comment: >
       Alarm.com devices, to my knowledge, do not exist on any local network. So they cannot be discovered.
-  docs-data-update:
-    status: done
-    comment: >
-      README.md's "Polling Intervals" section documents both timer-based
-      update mechanisms (activity feed/lock attribution, and the
-      full-state safety-net poll), their default intervals, and that
-      they're user-configurable via the options flow.
-  docs-examples:
-    status: done
-    comment: >
-      Working YAML automation examples in the "Auto-Off Timers", "Lock
-      Unlock Attribution", and "Activity Feed" sections - all validated
-      as real, parseable YAML.
-  docs-known-limitations:
-    status: done
-    comment: >
-      README.md's "Lock Unlock Attribution" section states plainly, with
-      the reasoning, that only keypad-code unlocks are attributed to a
-      person and that last_unlocked_by can lag behind the most recent
-      unlock for some lock models (see last_unlock_method).
-  docs-supported-devices:
-    status: done
-    comment: >
-      README.md's "Supported Devices" and "Supported Sensor Types" tables.
-  docs-supported-functions:
-    status: done
-    comment: >
-      Covered by the same "Supported Devices" table (actions column) plus
-      the dedicated feature sections (Auto-Off Timers, Lock Unlock
-      Attribution, Activity Feed, Camera Support).
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
   docs-troubleshooting: todo
-  docs-use-cases:
-    status: done
-    comment: >
-      The Auto-Off Timers, Lock Unlock Attribution, and Activity Feed
-      sections each open with the concrete problem they solve (e.g. the
-      welcome-home-by-name automation) rather than just listing
-      attributes, with working examples for each.
+  docs-use-cases: todo
   dynamic-devices:
     status: done
     comment: >
       Entities self-remove on RESOURCE_DELETED events. Binary sensors
       handle RESOURCE_ADDED for runtime additions. cleanup_orphaned_entities_and_devices
       in util.py removes stale entities and devices on each setup.
+      NOTE: When submitting this as a core integration, remove dynamic-devices
+      logic for the initial PR — HA submission guidelines list this as a
+      "complex quality scale rule" to exclude from a new integration's first
+      submission.
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: todo
@@ -174,19 +139,29 @@ rules:
       translation_key.
   exception-translations: todo
   icon-translations: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow:
+    status: todo
+    comment: >
+      NOTE: When submitting this as a core integration, the reconfiguration
+      flow may be too much for reviewers to want in an initial submission —
+      consider removing it and adding it back in a follow-up PR.
   repair-issues: todo
   stale-devices:
     status: done
     comment: >
       cleanup_orphaned_entities_and_devices in util.py removes devices
       with no remaining entities on each platform setup.
+      NOTE: Same as dynamic-devices — remove for the initial core PR per
+      HA submission guidelines.
 
   # Platinum
   async-dependency:
     status: done
     comment: >
       pyalarmdotcomajax is fully async and aiohttp-based.
+      However when submitting this integration as a core integration,
+      pyalarmdotcomajax has to be a seperate repo (like it was before)
+       because it is a requiremnt to become a core integration.
   inject-websession:
     status: todo
     comment: >

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -1,6 +1,11 @@
 rules:
   # Bronze
-  action-setup: done
+  action-setup:
+    status: done
+    comment: >
+      NOTE: When submitting this as a core integration, remove all custom
+      services for the initial PR — this rule becomes irrelevant until
+      services are added back in a follow-up PR.
   appropriate-polling:
     status: done
     comment: >
@@ -21,6 +26,8 @@ rules:
     comment: >
       Uses a custom AlarmHub class rather than DataUpdateCoordinator.
       Refactoring would be needed to adopt the common coordinator pattern.
+      NOTE: This would need to be resolved before submitting to HA core —
+      core integrations are expected to use DataUpdateCoordinator.
   config-flow: done
   config-flow-test-coverage:
     status: done
@@ -61,7 +68,12 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: done
+  action-exceptions:
+    status: done
+    comment: >
+      NOTE: When submitting this as a core integration, remove all custom
+      services for the initial PR — this rule becomes irrelevant until
+      services are added back in a follow-up PR.
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -27,7 +27,6 @@ rules:
       Uses a custom AlarmHub class rather than DataUpdateCoordinator.
       This is a Bronze blocker — the integration cannot claim Bronze (or Silver)
       compliance until AlarmHub is refactored to use DataUpdateCoordinator.
-      Intentionally left out of this PR due to scope; tracked separately.
   config-flow: done
   config-flow-test-coverage:
     status: done

--- a/custom_components/alarmdotcom/quality_scale.yaml
+++ b/custom_components/alarmdotcom/quality_scale.yaml
@@ -8,12 +8,10 @@ rules:
       poll runs as a safety net for missed events only.
   brands: done
   common-modules:
-    status: done
+    status: todo
     comment: >
-      AlarmCoordinator now inherits DataUpdateCoordinator[AlarmBridge].
-      All entities extend CoordinatorEntity and receive updates via
-      async_set_updated_data() rather than per-device hub.api.subscribe() calls.
-      AlarmHub is kept as a backward-compat alias (AlarmHub = AlarmCoordinator).
+      Uses a custom AlarmHub class rather than DataUpdateCoordinator.
+      Refactoring would be needed to adopt the common coordinator pattern.
   config-flow: done
   config-flow-test-coverage:
     status: done
@@ -45,10 +43,10 @@ rules:
   runtime-data:
     status: done
     comment: >
-      AlarmEntryData dataclass (coordinator, auto_off_manager, camera_session)
-      is stored as config_entry.runtime_data in async_setup_entry.
-      All platform files and diagnostics.py read from entry.runtime_data
-      instead of hass.data[DOMAIN][entry_id].
+      AlarmEntryData dataclass (hub, auto_off_manager, camera_session,
+      activity_feed_tracker) is stored as config_entry.runtime_data in
+      async_setup_entry. All platform files and diagnostics.py read from
+      entry.runtime_data instead of hass.data[DOMAIN][entry_id].
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done

--- a/custom_components/alarmdotcom/sensor.py
+++ b/custom_components/alarmdotcom/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DATA_ACTIVITY_FEED, DATA_AUTO_OFF, DATA_HUB, DOMAIN
+from .const import DOMAIN
 from .entity import (
     AdcControllerT,
     AdcEntity,
@@ -61,9 +61,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the sensor platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
-    auto_off_manager: AutoOffManager = hass.data[DOMAIN][config_entry.entry_id][DATA_AUTO_OFF]
-    activity_feed_tracker: ActivityFeedTracker = hass.data[DOMAIN][config_entry.entry_id][DATA_ACTIVITY_FEED]
+    hub: AlarmHub = config_entry.runtime_data.hub
+    auto_off_manager: AutoOffManager = config_entry.runtime_data.auto_off_manager
+    activity_feed_tracker: ActivityFeedTracker = config_entry.runtime_data.activity_feed_tracker
 
     entities: list[AdcSensorEntity] = []
     for entity_description in ENTITY_DESCRIPTIONS:

--- a/custom_components/alarmdotcom/strings.json
+++ b/custom_components/alarmdotcom/strings.json
@@ -62,6 +62,50 @@
             }
         }
     },
+    "services": {
+        "bypass_sensor": {
+            "name": "Bypass sensor",
+            "description": "Bypass a supported Alarm.com sensor.",
+            "fields": {
+                "resource_id": {
+                    "name": "Resource ID",
+                    "description": "Alarm.com resource ID for the sensor to bypass. Find this in the 'resource_id' attribute on the sensor's entity."
+                },
+                "partition_id": {
+                    "name": "Partition ID",
+                    "description": "Optional Alarm.com partition resource ID. If omitted, the first partition on the same system is used."
+                }
+            }
+        },
+        "unbypass_sensor": {
+            "name": "Unbypass sensor",
+            "description": "Remove bypass from a supported Alarm.com sensor.",
+            "fields": {
+                "resource_id": {
+                    "name": "Resource ID",
+                    "description": "Alarm.com resource ID for the sensor to unbypass."
+                },
+                "partition_id": {
+                    "name": "Partition ID",
+                    "description": "Optional Alarm.com partition resource ID. If omitted, the first partition on the same system is used."
+                }
+            }
+        },
+        "set_auto_off": {
+            "name": "Set auto-off timer",
+            "description": "Schedule one or more Alarm.com lights to turn off after a duration.",
+            "fields": {
+                "duration": {
+                    "name": "Duration",
+                    "description": "How long to wait before turning the light off."
+                }
+            }
+        },
+        "cancel_auto_off": {
+            "name": "Cancel auto-off timer",
+            "description": "Cancel a pending auto-off timer for one or more Alarm.com lights."
+        }
+    },
     "selector": {
         "otp_methods_list": {
             "options": {

--- a/custom_components/alarmdotcom/util.py
+++ b/custom_components/alarmdotcom/util.py
@@ -55,7 +55,7 @@ async def cleanup_orphaned_entities_and_devices(
             entity_registry.async_remove(entry.entity_id)
 
     # Remove orphaned devices with no entities left, but skip SERVICE devices
-    for device in list(device_registry.devices.values()):
+    for device in list(device_registry.devices):
         if (
             device.config_entries == {config_entry.entry_id}
             and device.entry_type != DeviceEntryType.SERVICE

--- a/custom_components/alarmdotcom/valve.py
+++ b/custom_components/alarmdotcom/valve.py
@@ -19,7 +19,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 

--- a/custom_components/alarmdotcom/valve.py
+++ b/custom_components/alarmdotcom/valve.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DATA_HUB, DOMAIN
+from .const import DOMAIN
 from .entity import AdcControllerT, AdcEntity, AdcEntityDescription, AdcManagedDeviceT
 from .util import cleanup_orphaned_entities_and_devices
 
@@ -42,7 +42,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the valve platform."""
 
-    hub: AlarmHub = hass.data[DOMAIN][config_entry.entry_id][DATA_HUB]
+    hub: AlarmHub = config_entry.runtime_data.hub
 
     entities = [
         AdcValveEntity(hub=hub, resource_id=resource.id, description=entity_description)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -11,7 +11,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.alarmdotcom.const import DATA_HUB, DOMAIN
+from custom_components.alarmdotcom import AlarmEntryData
+from custom_components.alarmdotcom.const import DOMAIN
 from custom_components.alarmdotcom.diagnostics import (
     async_get_config_entry_diagnostics,
     async_get_device_diagnostics,
@@ -64,7 +65,12 @@ async def test_config_entry_diagnostics_redacts_credentials(hass, mock_hub_with_
     """Username/password in config entry data must never appear unredacted."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_HUB: mock_hub_with_camera_resource}
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=None,
+        activity_feed_tracker=MagicMock(),
+    )
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
@@ -82,7 +88,12 @@ async def test_config_entry_diagnostics_redacts_camera_tokens(hass, mock_hub_wit
     """
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_HUB: mock_hub_with_camera_resource}
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=None,
+        activity_feed_tracker=MagicMock(),
+    )
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
@@ -99,7 +110,12 @@ async def test_config_entry_diagnostics_includes_connection_health(hass, mock_hu
     """Connection health (available, active system) is present and not redacted."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_HUB: mock_hub_with_camera_resource}
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=None,
+        activity_feed_tracker=MagicMock(),
+    )
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
@@ -111,7 +127,12 @@ async def test_device_diagnostics_filters_to_matching_device(hass, mock_hub_with
     """Device-level diagnostics only include resources matching that device's identifiers."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_HUB: mock_hub_with_camera_resource}
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=None,
+        activity_feed_tracker=MagicMock(),
+    )
 
     device = MagicMock()
     device.name = "Front Door Camera"
@@ -129,7 +150,12 @@ async def test_device_diagnostics_excludes_other_devices(hass, mock_hub_with_cam
     """A device page should not leak other devices' data."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_HUB: mock_hub_with_camera_resource}
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=None,
+        activity_feed_tracker=MagicMock(),
+    )
 
     device = MagicMock()
     device.name = "Some Other Device"
@@ -186,10 +212,12 @@ async def test_config_entry_diagnostics_includes_and_redacts_camera_session_data
     """
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        DATA_HUB: mock_hub_with_camera_resource,
-        "camera_session": mock_camera_session,
-    }
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=mock_camera_session,
+        activity_feed_tracker=MagicMock(),
+    )
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
@@ -206,10 +234,12 @@ async def test_config_entry_diagnostics_camera_session_none_is_reported_cleanly(
     """No camera session (e.g. camera login never succeeded) is reported, not a crash."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        DATA_HUB: mock_hub_with_camera_resource,
-        "camera_session": None,
-    }
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=None,
+        activity_feed_tracker=MagicMock(),
+    )
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
@@ -224,10 +254,12 @@ async def test_config_entry_diagnostics_camera_fetch_failure_does_not_break_whol
     entry.add_to_hass(hass)
     failing_session = MagicMock()
     failing_session.get_camera_list = AsyncMock(side_effect=ConnectionError("boom"))
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        DATA_HUB: mock_hub_with_camera_resource,
-        "camera_session": failing_session,
-    }
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=failing_session,
+        activity_feed_tracker=MagicMock(),
+    )
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
@@ -242,10 +274,12 @@ async def test_device_diagnostics_includes_matching_camera_only(
     """A camera's own device page includes its camera session data, filtered to just that camera."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_DATA)
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        DATA_HUB: mock_hub_with_camera_resource,
-        "camera_session": mock_camera_session,
-    }
+    entry.runtime_data = AlarmEntryData(
+        hub=mock_hub_with_camera_resource,
+        auto_off_manager=MagicMock(),
+        camera_session=mock_camera_session,
+        activity_feed_tracker=MagicMock(),
+    )
 
     device = MagicMock()
     device.name = "Front Door Camera"

--- a/tests/test_unload_service_teardown.py
+++ b/tests/test_unload_service_teardown.py
@@ -1,0 +1,67 @@
+"""Service teardown on unload, against a sibling entry that is not loaded."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.config_entries import ConfigEntryDisabler
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.alarmdotcom import async_unload_entry
+from custom_components.alarmdotcom.const import DOMAIN, SERVICE_BYPASS_SENSOR
+
+
+def _loaded_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Build a config entry in the state async_unload_entry expects to find it in."""
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="Alarm.com")
+    entry.add_to_hass(hass)
+    hub = MagicMock()
+    hub.close = AsyncMock(return_value=True)
+    runtime = MagicMock()
+    runtime.hub = hub
+    runtime.camera_session = None
+    runtime.auto_off_manager.async_unload = AsyncMock(return_value=None)
+    runtime.activity_feed_tracker.async_stop = MagicMock(return_value=None)
+    entry.runtime_data = runtime
+    return entry
+
+
+async def test_services_are_removed_when_the_last_loaded_entry_unloads(
+    hass: HomeAssistant,
+) -> None:
+    """The ordinary case: nothing else is loaded, so the services must go."""
+    entry = _loaded_entry(hass)
+    hass.services.async_register(DOMAIN, SERVICE_BYPASS_SENSOR, AsyncMock())
+
+    with patch.object(hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)):
+        await async_unload_entry(hass, entry)
+
+    assert not hass.services.has_service(DOMAIN, SERVICE_BYPASS_SENSOR)
+
+
+async def test_a_disabled_sibling_must_not_keep_the_services_registered(
+    hass: HomeAssistant,
+) -> None:
+    """
+    A disabled entry has no hub, so it cannot serve the services it keeps alive.
+
+    The teardown counts hass.config_entries.async_entries(DOMAIN), which defaults
+    to include_disabled=True and include_ignore=True. So a disabled sibling makes
+    `remaining` non-empty and the services survive - closed over the hub that
+    async_unload_entry has just closed one line above.
+    """
+    entry = _loaded_entry(hass)
+    disabled = MockConfigEntry(
+        domain=DOMAIN, data={}, title="Old account", disabled_by=ConfigEntryDisabler.USER
+    )
+    disabled.add_to_hass(hass)
+
+    hass.services.async_register(DOMAIN, SERVICE_BYPASS_SENSOR, AsyncMock())
+
+    with patch.object(hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)):
+        await async_unload_entry(hass, entry)
+
+    assert not hass.services.has_service(DOMAIN, SERVICE_BYPASS_SENSOR), (
+        "the only loaded entry is gone, so nothing can serve alarmdotcom.bypass_sensor"
+    )


### PR DESCRIPTION
## Summary

This PR helps bring the integration to Silver quality scale compliance with a few changes:

- **`config_entry.runtime_data`** (Bronze `runtime-data` rule): Replaces all `hass.data[DOMAIN]` reads/writes with a typed `AlarmEntryData` dataclass holding `hub`, `auto_off_manager`, `camera_session`, and `activity_feed_tracker`. Affects `__init__.py`, `hub.py`, all 10 platform files, and `diagnostics.py`.
- **`strings.json` services section** (Silver `docs-actions` rule/gold `entity translations`): Adds translatable names and descriptions for `bypass_sensor`, `unbypass_sensor`, `set_auto_off`, and `cancel_auto_off`.
- **`iot_class` recorrection**: `cloud_polling` -> `cloud_push`. You accidentally changed the iot class back to polling
- **Missing Bronze requirement**: only thing thats missing is common modules which will be done in a seperate pr
- **`quality_scale.yaml`**: Updated several requirements to reflect the changes in this, including notes on core submission considerations (activity feed polling on an undocumented endpoint, services to remove for initial submission, etc.).
- **`test_diagnostics.py`**: Updated to set `entry.runtime_data` directly instead of going through `hass.data`.
- **Newish docs**: The docs have been changed to add more info about stuff like MyQ and how some alarm.com products use z-wave, alongside some reformatting of stuff.
- **Ha core question**: I added notes in both the docs (hidden under a comment people wont see it) and the quality scale related to submitting this integration to ha, but im not sure if you're interested. If you aren't ill remove the notes, however considering you are making code quality adjustments after my pr adding the quality scale got submitted, i do feel like you are interested but i don’t know.

## Testing

All 106 tests pass. I have also been running this on my personal Home Assistant system and have not encountered any warnings or errors related to the integration in the logs.

> 🤖 Developed with [Claude Code](https://claude.ai/claude-code). 
