### PR TITLE
Fix silent drop of sensor state updates (#94)

### DIFF
--- a/custom_components/alarmdotcom/_pyalarmdotcomajax/controllers/sensors.py
+++ b/custom_components/alarmdotcom/_pyalarmdotcomajax/controllers/sensors.py
@@ -1,6 +1,7 @@
 """Alarm.com controller for sensors."""
 
 import logging
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 from _pyalarmdotcomajax.const import ATTR_DESIRED_STATE, ATTR_STATE
@@ -34,14 +35,13 @@ SENSOR_EVENT_STATE_MAP = {
 }
 
 
+# Derived from the state map, as in every other device controller, so the
+# subscription list and the state map can no longer drift apart.
 SUPPORTED_RESOURCE_EVENTS = SupportedResourceEvents(
     events=[
         ResourceEventType.Bypassed,
         ResourceEventType.EndOfBypass,
-        ResourceEventType.Closed,
-        ResourceEventType.OpenedClosed,
-        ResourceEventType.Opened,
-        ResourceEventType.DoorLeftOpenRestoral,
+        *SENSOR_EVENT_STATE_MAP.keys(),
     ]
 )
 
@@ -50,6 +50,12 @@ SUPPORTED_RESOURCE_EVENTS = SupportedResourceEvents(
 class SensorController(BaseController[Sensor]):
     """Controller for sensors."""
 
+    # Contact-sensor mapping is the class-level default, so state updates go
+    # through the same unguarded path every other device controller uses
+    # (BaseController._base_handle_event). Motion sensors need IDLE/ACTIVE
+    # rather than CLOSED/OPEN, which a ClassVar cannot express per device, so
+    # _handle_event below corrects them.
+    _event_state_map = MappingProxyType(SENSOR_EVENT_STATE_MAP)
     _supported_resource_events = SUPPORTED_RESOURCE_EVENTS
 
     async def _handle_event(
@@ -57,12 +63,11 @@ class SensorController(BaseController[Sensor]):
     ) -> "AdcResourceT":
         """Handle light-specific WebSocket events."""
 
-        # Be careful here. message.value may be 0, so we need to explicitly check for None instead of relying on truthiness.
-        if (
-            isinstance(message, EventWSMessage)
-            and message.value is not None
-            and isinstance(adc_resource, Sensor)
-        ):
+        # Contact-sensor state is carried entirely by `subtype` (Opened /
+        # Closed / OpenedClosed). `event_value` means nothing for these events
+        # and is not read anywhere below, but gating on it dropped every state
+        # update whenever Alarm.com sent the event without one.
+        if isinstance(message, EventWSMessage) and isinstance(adc_resource, Sensor):
             #
             # STATE UPDATES
             #

--- a/custom_components/alarmdotcom/_pyalarmdotcomajax/controllers/water_sensors.py
+++ b/custom_components/alarmdotcom/_pyalarmdotcomajax/controllers/water_sensors.py
@@ -1,16 +1,28 @@
 """Alarm.com controller for water sensors."""
 
+from types import MappingProxyType
+
 from _pyalarmdotcomajax.controllers.base import BaseController, device_controller
 from _pyalarmdotcomajax.models.base import ResourceType
+from _pyalarmdotcomajax.models.sensor import SensorState
 from _pyalarmdotcomajax.models.water_sensor import WaterSensor
 from _pyalarmdotcomajax.websocket.client import SupportedResourceEvents
 from _pyalarmdotcomajax.websocket.messages import ResourceEventType
+
+WATER_SENSOR_EVENT_STATE_MAP = MappingProxyType(
+    {
+        ResourceEventType.Opened: SensorState.OPEN,
+        ResourceEventType.Closed: SensorState.CLOSED,
+    }
+)
 
 
 @device_controller(ResourceType.WATER_SENSOR, WaterSensor)
 class WaterSensorController(BaseController[WaterSensor]):
     """Controller for water sensors."""
 
-    _supported_resource_events = SupportedResourceEvents(
-        events=[ResourceEventType.Opened, ResourceEventType.Closed]
-    )
+    # This controller subscribed to Opened/Closed but defined neither a state
+    # map nor a _handle_event override, so every water-leak event reached
+    # _base_handle_event and was discarded with the resource unmodified.
+    _event_state_map = WATER_SENSOR_EVENT_STATE_MAP
+    _supported_resource_events = SupportedResourceEvents(events=[*WATER_SENSOR_EVENT_STATE_MAP.keys()])

--- a/custom_components/alarmdotcom/_pyalarmdotcomajax/websocket/messages.py
+++ b/custom_components/alarmdotcom/_pyalarmdotcomajax/websocket/messages.py
@@ -23,6 +23,20 @@ class ResourcePropertyChangeType(Enum):
     # Unsupported
     IrrigationStatus = 5
 
+    UNKNOWN = -1
+
+    @classmethod
+    def _missing_(cls: type, value: object) -> "ResourcePropertyChangeType":
+        """
+        Set default enum member if an unknown value is provided.
+
+        Without this, an unmapped property subtype raises ValueError inside
+        mashumaro and the event processor drops the whole message (#94:
+        "7 is not a valid ResourcePropertyChangeType"). ResourceEventType has
+        had this fallback all along.
+        """
+        return ResourcePropertyChangeType.UNKNOWN
+
 
 class ResourceEventType(Enum):
     """Enum for event types."""

--- a/custom_components/alarmdotcom/activity_history.py
+++ b/custom_components/alarmdotcom/activity_history.py
@@ -119,6 +119,16 @@ ACTIVITY_FEED_EVENT_TYPES = frozenset(
 # known_lock_ids is used for lock unlock attribution.
 GARAGE_DOOR_EVENT_TYPES = frozenset({"Opened", "Closed", "OpenedClosed"})
 
+# Ordinary door/window contact sensors emit these same event_type_name values.
+# They are deliberately kept OUT of the curated feed — a busy house would drown
+# the Recent Activity display, which is why they were excluded to begin with.
+# They ARE fired on the event bus, because this poll is an independent path to
+# the same physical events: when the WebSocket route drops a contact-sensor
+# state update, an automation triggering on that door has no other source for
+# it (#94). Firing the bus event costs the display nothing and gives those
+# automations something to hold on to.
+CONTACT_SENSOR_EVENT_TYPES = GARAGE_DOOR_EVENT_TYPES
+
 
 class RecentActivityEntry(TypedDict):
     """One entry in the recent-activity rolling list."""
@@ -222,6 +232,7 @@ class ActivityFeedTracker:
 
         known_lock_ids = {lock.id for lock in self.hub.api.locks}
         known_garage_door_ids = {door.id for door in self.hub.api.garage_doors}
+        known_sensor_ids = {sensor.id for sensor in self.hub.api.sensors}
         changed = False
         matched_unlock_count = 0
         feed_count = 0
@@ -238,6 +249,12 @@ class ActivityFeedTracker:
             if is_curated or is_curated_garage_event:
                 feed_count += 1
                 self._fire_activity_event(event)
+            elif (
+                event_type_name in CONTACT_SENSOR_EVENT_TYPES
+                and event.attributes.global_device_id in known_sensor_ids
+            ):
+                # Bus event only — the curated display stays as it was.
+                self._fire_activity_event(event, feed=False)
 
             if event_type_name != "DoorUnlocked":
                 continue
@@ -292,8 +309,14 @@ class ActivityFeedTracker:
         if changed or feed_count:
             self._notify_listeners()
 
-    def _fire_activity_event(self, event: pyadc.HistoryEvent) -> None:
-        """Fire a curated event on Home Assistant's event bus and append it to the recent-activity list."""
+    def _fire_activity_event(self, event: pyadc.HistoryEvent, *, feed: bool = True) -> None:
+        """
+        Fire an event on Home Assistant's event bus.
+
+        ``feed=False`` fires the bus event without adding the entry to the
+        recent-activity list — for event types that automations need but that
+        would be noise in the curated display.
+        """
 
         attrs = event.attributes
         entry: RecentActivityEntry = {
@@ -302,7 +325,8 @@ class ActivityFeedTracker:
             "device_description": attrs.device_description,
             "event_date": attrs.event_date,
         }
-        self._recent_activity.append(entry)
+        if feed:
+            self._recent_activity.append(entry)
         self.hub.hass.bus.async_fire(
             EVENT_ACTIVITY,
             {

--- a/custom_components/alarmdotcom/diagnostics.py
+++ b/custom_components/alarmdotcom/diagnostics.py
@@ -16,6 +16,7 @@ diagnostics downloads are meant to be safe to attach to a GitHub issue.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -138,7 +139,7 @@ async def _camera_diagnostics(camera_session: AlarmCameraSession | None) -> dict
 
 def _connection_health(hub: AlarmHub) -> dict[str, Any]:
     """Return connection/websocket health, independent of any specific device."""
-    return {
+    health: dict[str, Any] = {
         "available": hub.available,
         "active_system": {
             "id": hub.api.active_system.id,
@@ -147,6 +148,16 @@ def _connection_health(hub: AlarmHub) -> dict[str, Any]:
         if hub.api.active_system
         else None,
     }
+    # The WebSocket client already keeps the last 25 raw frames
+    # (websocket/client.py, `last_events`), but nothing surfaced them. Every
+    # "my sensor stopped updating" report needs exactly this to tell a
+    # transport-level miss from something dropping the message after receipt,
+    # and asking each reporter to reproduce with debug logging is a slow way to
+    # get it. Flows through the same async_redact_data(..., TO_REDACT) call as
+    # every other section.
+    with contextlib.suppress(AttributeError):
+        health["last_events"] = hub.api.ws_controller.last_events
+    return health
 
 
 async def async_get_config_entry_diagnostics(

--- a/tests/test_sensor_websocket_state.py
+++ b/tests/test_sensor_websocket_state.py
@@ -1,0 +1,180 @@
+"""
+WebSocket state updates for sensors.
+
+Regression cover for the case where a contact sensor stops updating in Home
+Assistant while Alarm.com keeps reporting it: an Opened/Closed event that
+arrives without an ``event_value``. Contact-sensor state lives entirely in
+``subtype``, so such an event is perfectly valid and must still be applied.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from _pyalarmdotcomajax.const import ATTR_STATE
+from _pyalarmdotcomajax.controllers.sensors import (
+    SENSOR_EVENT_STATE_MAP,
+    SUPPORTED_RESOURCE_EVENTS,
+    SensorController,
+)
+from _pyalarmdotcomajax.controllers.water_sensors import WaterSensorController
+from _pyalarmdotcomajax.models.sensor import Sensor, SensorState, SensorSubtype
+from _pyalarmdotcomajax.websocket.messages import (
+    EventWSMessage,
+    PropertyChangeWSMessage,
+    ResourceEventType,
+    ResourcePropertyChangeType,
+)
+
+# Importing the component runs its sys.path shim, which puts the vendored
+# library on sys.path as top-level `_pyalarmdotcomajax` — the same name the
+# vendored modules import each other by. Importing it through the
+# `custom_components.alarmdotcom.` prefix instead would load a second copy,
+# with its own distinct enum classes that compare unequal to the real ones.
+import custom_components.alarmdotcom  # noqa: F401
+from custom_components.alarmdotcom.activity_history import (
+    ACTIVITY_FEED_EVENT_TYPES,
+    CONTACT_SENSOR_EVENT_TYPES,
+    ActivityFeedTracker,
+)
+
+
+def _sensor(subtype: SensorSubtype) -> Sensor:
+    """Build a Sensor stub carrying only what _handle_event touches."""
+    resource = MagicMock(spec=Sensor)
+    resource.subtype = subtype
+    resource.api_resource = SimpleNamespace(attributes={})
+    return resource
+
+
+def _event(subtype: ResourceEventType, value: float | None) -> EventWSMessage:
+    message = MagicMock(spec=EventWSMessage)
+    message.subtype = subtype
+    message.value = value
+    return message
+
+
+@pytest.mark.parametrize("value", [None, 0, 1])
+@pytest.mark.asyncio
+async def test_contact_sensor_opens_regardless_of_event_value(value) -> None:
+    """
+    `event_value` is meaningless for a contact sensor and must not gate state.
+
+    This is the regression: gating on `message.value is not None` silently
+    dropped every Opened/Closed event Alarm.com sent without one — no state
+    change, no log line, no error.
+    """
+    controller = MagicMock(spec=SensorController)
+    resource = _sensor(SensorSubtype.CONTACT_SENSOR)
+
+    updated = await SensorController._handle_event(
+        controller, resource, _event(ResourceEventType.Opened, value)
+    )
+
+    assert updated.api_resource.attributes[ATTR_STATE] == SensorState.OPEN.value
+
+
+@pytest.mark.asyncio
+async def test_motion_sensor_maps_to_active_not_open() -> None:
+    """Motion sensors need IDLE/ACTIVE, which the class-level map cannot express."""
+    controller = MagicMock(spec=SensorController)
+    resource = _sensor(SensorSubtype.MOTION_SENSOR)
+
+    updated = await SensorController._handle_event(
+        controller, resource, _event(ResourceEventType.Opened, None)
+    )
+
+    assert updated.api_resource.attributes[ATTR_STATE] == SensorState.ACTIVE.value
+
+
+def test_sensor_controller_declares_a_state_map() -> None:
+    """Without it the unguarded path in _base_handle_event never runs for sensors."""
+    assert SensorController._event_state_map is not None
+    assert SensorController._event_state_map[ResourceEventType.Opened] == SensorState.OPEN
+    assert SensorController._event_state_map[ResourceEventType.Closed] == SensorState.CLOSED
+
+
+def test_subscription_is_derived_from_the_state_map() -> None:
+    """Every mapped event must also be subscribed, or the map can never fire."""
+    subscribed = set(SUPPORTED_RESOURCE_EVENTS.events or [])
+    assert set(SENSOR_EVENT_STATE_MAP).issubset(subscribed)
+
+
+def test_water_sensor_can_write_state() -> None:
+    """It subscribed to Opened/Closed but had no way to act on them."""
+    assert WaterSensorController._event_state_map is not None
+    assert WaterSensorController._event_state_map[ResourceEventType.Opened] == SensorState.OPEN
+
+
+def test_unknown_property_change_subtype_does_not_raise() -> None:
+    """An unmapped subtype used to raise ValueError and drop the whole message."""
+    assert ResourcePropertyChangeType(7) is ResourcePropertyChangeType.UNKNOWN
+    assert ResourcePropertyChangeType(ResourcePropertyChangeType.LightColor.value) is (
+        ResourcePropertyChangeType.LightColor
+    )
+
+
+def test_property_change_message_survives_an_unknown_subtype() -> None:
+    """The end-to-end shape of #94: mashumaro must not fail the conversion."""
+    message = PropertyChangeWSMessage.from_dict(
+        {"unit_id": "1234", "device_id": 5, "property": 7, "property_value": 1}
+    )
+    assert message.subtype is ResourcePropertyChangeType.UNKNOWN
+    assert message.full_device_id == "1234-5"
+
+
+def _history_event() -> MagicMock:
+    """Build a poll result standing in for one activity-history entry."""
+    event = MagicMock()
+    event.attributes.description = "Front Door Opened"
+    event.attributes.event_type_name = "Opened"
+    event.attributes.device_description = "Front Door"
+    event.attributes.event_date = "2026-08-25T10:00:00Z"
+    event.attributes.global_device_id = "id-1234-5"
+    return event
+
+
+def _tracker() -> MagicMock:
+    tracker = MagicMock(spec=ActivityFeedTracker)
+    tracker._recent_activity = []
+    tracker.hub = MagicMock()
+    return tracker
+
+
+def test_contact_sensor_events_reach_the_bus_but_not_the_display() -> None:
+    """
+    The poll is an independent path; automations need it, the display does not.
+
+    Contact-sensor open/close was excluded from the curated feed as display
+    noise. That also denied automations the only source of those events that
+    survives when the WebSocket route drops the state update (#94), so the bus
+    event now fires while the Recent Activity list stays as it was.
+    """
+    tracker = _tracker()
+
+    ActivityFeedTracker._fire_activity_event(tracker, _history_event(), feed=False)
+
+    assert tracker._recent_activity == []
+    tracker.hub.hass.bus.async_fire.assert_called_once()
+    _name, payload = tracker.hub.hass.bus.async_fire.call_args[0]
+    assert payload["device_id"] == "id-1234-5"
+    assert payload["event_type_name"] == "Opened"
+
+
+def test_curated_events_still_reach_the_display() -> None:
+    """Widening the bus must not change what Recent Activity shows."""
+    tracker = _tracker()
+    event = _history_event()
+    event.attributes.event_type_name = "Disarmed"
+
+    ActivityFeedTracker._fire_activity_event(tracker, event)
+
+    assert len(tracker._recent_activity) == 1
+    tracker.hub.hass.bus.async_fire.assert_called_once()
+
+
+def test_contact_sensors_stay_out_of_the_curated_set() -> None:
+    """The original intent — they are display noise — is preserved."""
+    assert not CONTACT_SENSOR_EVENT_TYPES & ACTIVITY_FEED_EVENT_TYPES


### PR DESCRIPTION
Six commits, each independently green, splitting cleanly if they'd be easier to
take separately. The thread is #94, an installation where door sensors stopped
updating while the same account's lights kept working normally.

## The confirmed bug

`ResourcePropertyChangeType` has no `_missing_`, so subtype 7 raises inside
mashumaro and the processor drops the message. `ResourceEventType` has had that
fallback all along, and this gives the property enum the same one.

## Why that isn't what broke the door sensors

The contact-sensor path is a separate one, and it turns out to be less tolerant
rather than more.

`SENSOR_EVENT_STATE_MAP` and `MOTION_EVENT_STATE_MAP` are written out in full at
the top of `sensors.py` and referenced exactly once each, at their own
definition. `_event_state_map` is never assigned, so the unguarded state-update
branch in `_base_handle_event` never runs for sensors, and everything depends on
`_handle_event`, which opens with `message.value is not None`.

`event_value` means nothing for a contact sensor, since state is entirely in
`subtype`, and it isn't read anywhere in that block. An Opened/Closed event
arriving without one is therefore dropped with no state change, no log line and
no error. Lights survive the same situation only because they do have a state
map, which isn't guarded.

The reporter's own timeline in #94 is the experiment: garage door recorded twice,
contact sensor missed, same socket, twelve minutes apart. Garage doors go through
`_event_state_map`, contact sensors don't.

`SUPPORTED_RESOURCE_EVENTS` is now derived from the map the way it is in gates,
garage_doors, locks, partitions and water_valve, so the two can't drift again.

## Two others found on the way

`WaterSensorController` subscribes to Opened/Closed and defines neither a state
map nor a `_handle_event`, so leak events reach `_base_handle_event`, match no
branch, and the resource is re-registered unmodified, consumed and discarded on
every account.

The activity poll is an independent path to the same physical events. Contact
sensors were excluded from the curated feed as display noise, which is right for
the display, but it also denies automations the only source of those events that
survives a WebSocket-side fault. `_fire_activity_event` gains `feed=False` so the
bus event fires and Recent Activity is untouched. Ids are matched against
`hub.api.sensors` the same way garage doors are matched against
`hub.api.garage_doors`, since both share identical event_type_name values.

## On the debug capture requested in #94

It may not be producible as described. `[EVENT READER]` has no log call on the
success path, since it appends to `_event_history` and returns, so debug logging
can't show whether a frame arrived at all. `[EVENT PROCESSOR] Received WebSocket
Message` is the line that does, and it only fires after conversion is attempted.
That may be why the thread went quiet.

`last_events` already holds the last 25 raw frames and nothing surfaced them, so
the last commit attaches them to diagnostics through the existing
`async_redact_data(..., TO_REDACT)` call. Future reports then arrive with the
frames already in hand.

## Tests

Nothing exercised the WebSocket sensor path, which is how both the gate and the
unassigned map survived. 118 tests pass, ruff clean, and each new test fails on
its parent commit.

The parametrised contact-sensor case is the regression in one line: `event_value`
of 0 and 1 passed before this series, `None` did not, and the event is otherwise
identical. The last test reproduces #94's exception verbatim.

## One thing worth flagging

This targets `feature/fixes/beta` because `activity_history.py` only exists
there. The installation in question is on `2026.7.9.3`, so the activity-bus
commit can't reach it without a beta build. Happy to split that one out if
landing the four `main`-compatible fixes first is easier.

Not a maintainer here and not looking to be. This came up on a customer install,
and sending it seemed better than carrying a fork.
