### PR TITLE
Use the device registry APIs that survive HA Core 2027 (#101)

### DIFF
--- a/custom_components/alarmdotcom/button.py
+++ b/custom_components/alarmdotcom/button.py
@@ -106,9 +106,13 @@ class AdcButtonDescription(
 def _device_exists_in_registry(hub: AlarmHub, resource_id: str) -> bool:
     """Check if a device with the given ID exists in the device registry."""
     device_registry = dr.async_get(hub.hass)
-    return any(
-        (DOMAIN, resource_id) in device.identifiers
-        for device in device_registry.devices.values()
+    # Scoped lookup rather than a scan of device_registry.devices, whose mapping
+    # interface is deprecated and stops working in HA Core 2027.9.
+    return (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, resource_id), hub.config_entry.entry_id
+        )
+        is not None
     )
 
 

--- a/custom_components/alarmdotcom/entity.py
+++ b/custom_components/alarmdotcom/entity.py
@@ -73,9 +73,12 @@ def device_info_fn(hub: AlarmHub, resource_id: str, entity_name: str | None) -> 
     """
     Return device information.
 
-    Home Assistant 2025.12 will enforce that via_device must reference an existing device.
-    Historically this integration sometimes set via_device to (DOMAIN, None) or to ids that
-    were never created as devices, which causes warnings and will become a hard failure.
+    Home Assistant 2025.12 will enforce that the parent link must reference an existing
+    device. Historically this integration sometimes pointed it at (DOMAIN, None) or at ids
+    that were never created as devices, which causes warnings and will become a hard failure.
+
+    The link is published as ``via_device_id`` (the parent's device registry id). The older
+    ``via_device`` identifier tuple is deprecated and stops working in HA Core 2027.8.
     """
 
     resource = hub.api.managed_devices[resource_id]
@@ -96,29 +99,35 @@ def device_info_fn(hub: AlarmHub, resource_id: str, entity_name: str | None) -> 
     if resource.attributes.device_model is not None:
         device_info["model"] = resource.attributes.device_model
 
-    # Determine parent device candidate (prefer system device).
+    # Determine parent device candidate (prefer system device). This is the parent's
+    # Alarm.com resource id, i.e. the second half of its (DOMAIN, ...) identifier - not
+    # the device registry id that via_device_id wants.
     system_id: str | None = getattr(hub.api.active_system, "id", None)
-    via_device_id: str | None = None
+    parent_resource_id: str | None = None
 
     # Do not attach the system device to anything.
     if system_id and resource_id != system_id:
         # Prefer partition device if it exists as a device, otherwise fall back to system.
         partition_id = hub.api.partitions.get_device_partition(resource_id)
         if isinstance(partition_id, str) and partition_id.strip():
-            via_device_id = partition_id
+            parent_resource_id = partition_id
         else:
             resource_system_id = getattr(resource, "system_id", None)
             if isinstance(resource_system_id, str) and resource_system_id.strip():
-                via_device_id = resource_system_id
+                parent_resource_id = resource_system_id
             else:
-                via_device_id = system_id
+                parent_resource_id = system_id
 
-    # Only set via_device when the referenced device actually exists.
-    if isinstance(via_device_id, str) and via_device_id.strip():
+    # Only publish the parent link when the referenced device actually exists, and publish
+    # it as the parent's registry id. async_get_device_by_identifier scopes the lookup to
+    # this config entry, where identifiers are unique, so the match cannot be ambiguous.
+    if isinstance(parent_resource_id, str) and parent_resource_id.strip():
         device_registry = dr.async_get(hub.hass)
-        parent_device = device_registry.async_get_device(identifiers={(DOMAIN, via_device_id)})
+        parent_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, parent_resource_id), hub.config_entry.entry_id
+        )
         if parent_device is not None:
-            device_info["via_device"] = (DOMAIN, via_device_id)
+            device_info["via_device_id"] = parent_device.id
 
     return device_info
 

--- a/custom_components/alarmdotcom/util.py
+++ b/custom_components/alarmdotcom/util.py
@@ -2,7 +2,10 @@
 
 from typing import TYPE_CHECKING
 
-from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.device_registry import (
+    DeviceEntryType,
+    async_entries_for_config_entry,
+)
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 
@@ -54,8 +57,14 @@ async def cleanup_orphaned_entities_and_devices(
         if not matched_by_entity_id and not matched_by_unique_id:
             entity_registry.async_remove(entry.entity_id)
 
-    # Remove orphaned devices with no entities left, but skip SERVICE devices
-    for device in list(device_registry.devices.values()):
+    # Remove orphaned devices with no entities left, but skip SERVICE devices.
+    # async_entries_for_config_entry rather than device_registry.devices, whose mapping
+    # interface is deprecated and stops working in HA Core 2027.9. The helper already
+    # narrows to devices this entry touches; the check below keeps only those it owns
+    # outright, which is the same set the previous full scan selected.
+    for device in list(
+        async_entries_for_config_entry(device_registry, config_entry.entry_id)
+    ):
         if (
             device.config_entries == {config_entry.entry_id}
             and device.entry_type != DeviceEntryType.SERVICE

--- a/tests/test_device_registry_links.py
+++ b/tests/test_device_registry_links.py
@@ -1,0 +1,179 @@
+"""
+Device registry usage, held to the APIs that survive HA Core 2027.
+
+Three deprecations were reported in #101, all of them on paths this integration
+takes on every setup:
+
+* ``DeviceInfo["via_device"]`` — the identifier-tuple form of the parent link,
+  removed in HA Core 2027.8 in favour of ``via_device_id`` (a registry id);
+* ``DeviceRegistry.async_get_device(identifiers=...)`` — ambiguous across config
+  entries, superseded by ``async_get_device_by_identifier``;
+* ``device_registry.devices`` used as a mapping — removed in HA Core 2027.9.
+
+The last one is not merely a warning on current betas: it raises. These tests
+assert the shape of what we emit and the helpers we call, so a regression fails
+here rather than in a user's log.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.alarmdotcom.button import _device_exists_in_registry
+from custom_components.alarmdotcom.const import DOMAIN
+from custom_components.alarmdotcom.entity import device_info_fn
+from custom_components.alarmdotcom.util import cleanup_orphaned_entities_and_devices
+
+
+@pytest.fixture
+def hub(hass: HomeAssistant) -> MagicMock:
+    """Build a hub whose registry-facing surface is real: hass and a live config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="Alarm.com")
+    entry.add_to_hass(hass)
+
+    hub = MagicMock()
+    hub.hass = hass
+    hub.config_entry = entry
+    hub.api.active_system.id = "system-1"
+    hub.api.partitions.get_device_partition.return_value = None
+    return hub
+
+
+def _register(hass: HomeAssistant, entry_id: str, resource_id: str) -> dr.DeviceEntry:
+    return dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(DOMAIN, resource_id)},
+        name=resource_id,
+    )
+
+
+def _managed(hub: MagicMock, resource_id: str, *, system_id: str | None = None) -> None:
+    resource = MagicMock()
+    resource.id = resource_id
+    resource.name = resource_id
+    resource.system_id = system_id
+    resource.attributes.mac_address = None
+    resource.attributes.manufacturer = None
+    resource.attributes.device_model = None
+    hub.api.managed_devices = {resource_id: resource}
+
+
+def test_parent_link_is_a_registry_id_not_an_identifier_tuple(hass: HomeAssistant, hub: MagicMock) -> None:
+    """The link must be published as via_device_id, carrying the parent's registry id."""
+    parent = _register(hass, hub.config_entry.entry_id, "system-1")
+    _managed(hub, "sensor-1", system_id="system-1")
+
+    info = device_info_fn(hub, "sensor-1", None)
+
+    assert "via_device" not in info, "via_device is removed in HA Core 2027.8"
+    assert info["via_device_id"] == parent.id
+    # the registry id is not the Alarm.com resource id — a swap would silently unlink
+    assert info["via_device_id"] != "system-1"
+
+
+def test_no_parent_link_when_the_parent_was_never_registered(hass: HomeAssistant, hub: MagicMock) -> None:
+    """An unregistered parent must produce no link at all, not a dangling one."""
+    _managed(hub, "sensor-1", system_id="system-1")
+
+    info = device_info_fn(hub, "sensor-1", None)
+
+    assert "via_device_id" not in info
+    assert "via_device" not in info
+
+
+def test_the_system_device_is_not_linked_to_itself(hass: HomeAssistant, hub: MagicMock) -> None:
+    """The system is the root of the tree, so it must not be given a parent."""
+    _register(hass, hub.config_entry.entry_id, "system-1")
+    _managed(hub, "system-1", system_id="system-1")
+
+    info = device_info_fn(hub, "system-1", None)
+
+    assert "via_device_id" not in info
+
+
+def test_partition_is_preferred_over_system_as_the_parent(hass: HomeAssistant, hub: MagicMock) -> None:
+    """A registered partition is the nearer parent and wins over the system."""
+    _register(hass, hub.config_entry.entry_id, "system-1")
+    partition = _register(hass, hub.config_entry.entry_id, "partition-1")
+    hub.api.partitions.get_device_partition.return_value = "partition-1"
+    _managed(hub, "sensor-1", system_id="system-1")
+
+    info = device_info_fn(hub, "sensor-1", None)
+
+    assert info["via_device_id"] == partition.id
+
+
+def test_parent_lookup_ignores_an_identical_identifier_on_another_entry(hass: HomeAssistant, hub: MagicMock) -> None:
+    """
+    Identifiers are unique per entry, not globally.
+
+    A second Alarm.com account registering the same resource id must not become
+    the parent — which is exactly the ambiguity async_get_device carried and
+    async_get_device_by_identifier removes.
+    """
+    other = MockConfigEntry(domain=DOMAIN, data={}, title="Second account")
+    other.add_to_hass(hass)
+    _register(hass, other.entry_id, "system-1")
+    _managed(hub, "sensor-1", system_id="system-1")
+
+    info = device_info_fn(hub, "sensor-1", None)
+
+    assert "via_device_id" not in info
+
+
+def test_device_exists_in_registry_is_scoped_to_this_entry(hass: HomeAssistant, hub: MagicMock) -> None:
+    """The scan this replaced saw every device, so a second account counted as ours."""
+    other = MockConfigEntry(domain=DOMAIN, data={}, title="Second account")
+    other.add_to_hass(hass)
+    _register(hass, other.entry_id, "elsewhere")
+    _register(hass, hub.config_entry.entry_id, "here")
+
+    assert _device_exists_in_registry(hub, "here") is True
+    assert _device_exists_in_registry(hub, "elsewhere") is False
+    assert _device_exists_in_registry(hub, "never-created") is False
+
+
+async def test_orphan_cleanup_reaches_the_same_devices_as_the_old_full_scan(
+    hass: HomeAssistant,
+) -> None:
+    """
+    The orphan sweep must select the same devices it selected through the old scan.
+
+    It previously walked ``device_registry.devices.values()`` — every device in the
+    installation — and filtered afterwards. That mapping access raises on HA Core
+    2026.9 betas and is removed in 2027.9, so the walk now starts from this entry's
+    own devices. Narrowing the walk must not narrow the outcome: our own orphan still
+    goes, a device that still has a live entity stays, and another entry's orphan was
+    never ours to remove.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="Alarm.com")
+    entry.add_to_hass(hass)
+    other = MockConfigEntry(domain=DOMAIN, data={}, title="Second account")
+    other.add_to_hass(hass)
+
+    registry = dr.async_get(hass)
+    ours_orphan = _register(hass, entry.entry_id, "ours-orphan")
+    ours_live = _register(hass, entry.entry_id, "ours-live")
+    theirs_orphan = _register(hass, other.entry_id, "theirs-orphan")
+
+    entity_registry = er.async_get(hass)
+    live = entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "ours-live-sensor",
+        config_entry=entry,
+        device_id=ours_live.id,
+    )
+
+    await cleanup_orphaned_entities_and_devices(hass, entry, {live.entity_id}, {"ours-live-sensor"}, "sensor")
+
+    assert registry.async_get(ours_orphan.id) is None, "our own orphan should be swept"
+    assert registry.async_get(ours_live.id) is not None, "a device with a live entity stays"
+    assert registry.async_get(theirs_orphan.id) is not None, "another entry's device is not ours"
+    assert entity_registry.async_get(live.entity_id) is not None


### PR DESCRIPTION
Closes #101.

Three deprecations, all on paths this integration takes on every setup. The third
already raises rather than warns on 2026.9 betas, so this is not only future work.

**`DeviceInfo["via_device"]` → `via_device_id`.** The identifier-tuple form of the
parent link is removed in HA Core 2027.8. `via_device_id` carries the parent's
device registry id instead. The local holding the parent's Alarm.com resource id
was itself named `via_device_id`, which is the one id it is not, so it is renamed
`parent_resource_id` to keep the two apart.

**`async_get_device(identifiers=...)` → `async_get_device_by_identifier`.** The
former resolves across config entries and can match another account's device;
the latter scopes the lookup to this entry, where identifiers are unique.

**`device_registry.devices` as a mapping.** Removed in HA Core 2027.9 and already
raising on 2026.9 betas. The orphan sweep now starts from this entry's own devices
via `async_entries_for_config_entry`, and the button availability check is a scoped
lookup rather than a scan of every device in the installation.

That last one was also a live bug: `_device_exists_in_registry` scanned the whole
registry, so a second Alarm.com account registering the same resource id made the
debug button appear on an account that has no such device.

### Tests

Adds `tests/test_device_registry_links.py`. None of the three functions had any
coverage before. Three of its seven cases fail without this change; the rest pin
behaviour that must not move, including that the orphan sweep still selects the
same devices from the narrower walk.

Full suite: 113 passed.