### PR TITLE
climate.set_fan_mode drops "auto" without calling the API (#99)

### DIFF
--- a/custom_components/alarmdotcom/climate.py
+++ b/custom_components/alarmdotcom/climate.py
@@ -286,7 +286,11 @@ async def set_hvac_mode_fn(
         HVACMode.HEAT_COOL: pyadc.thermostat.ThermostatState.AUTO,
     }
 
-    if requested_hvac_mode := state_map.get(hvac_mode):
+    # `is not None`, not truthiness: these are IntEnum members, so a mode whose
+    # value is 0 is falsy. ThermostatState.OFF is 1 today, but the same test one
+    # function below silently dropped every "auto" fan request (see #99).
+    requested_hvac_mode = state_map.get(hvac_mode)
+    if requested_hvac_mode is not None:
         await controller.set_state(thermostat_id, state=requested_hvac_mode)
 
 
@@ -303,7 +307,12 @@ async def set_fan_mode_fn(
         FAN_CIRCULATE: pyadc.thermostat.ThermostatFanMode.CIRCULATE,
     }
 
-    if requested_fan_mode := fan_mode_map.get(fan_mode):
+    # ThermostatFanMode is an IntEnum and AUTO is 0, so a truthiness test here
+    # discards exactly the mode most thermostats sit in: climate.set_fan_mode
+    # with "auto" returned without calling the API and without raising, which is
+    # what #99 saw as an automation that fires and never reaches the thermostat.
+    requested_fan_mode = fan_mode_map.get(fan_mode)
+    if requested_fan_mode is not None:
         await controller.set_state(thermostat_id, fan_mode=requested_fan_mode, fan_mode_duration=0)
 
 

--- a/tests/test_climate_set_modes.py
+++ b/tests/test_climate_set_modes.py
@@ -1,0 +1,90 @@
+"""
+Thermostat mode setters, held against the zero-valued enum member.
+
+ThermostatFanMode and ThermostatState are IntEnums whose first real member is 0
+(ThermostatFanMode.AUTO). The setters looked their argument up in a dict and
+gated the API call on the RESULT'S TRUTHINESS, so "auto" resolved correctly,
+evaluated false, and the function returned without calling the API and without
+raising - an automation that fires, reports success, and never reaches the
+thermostat (#99).
+
+These tests pin the two properties that matter: a supported mode reaches the
+API, and an unsupported one does not.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.components.climate import FAN_AUTO, FAN_ON, HVACMode
+
+from custom_components.alarmdotcom import _pyalarmdotcomajax as pyadc
+from custom_components.alarmdotcom.climate import set_fan_mode_fn, set_hvac_mode_fn
+
+FAN_CIRCULATE = "circulate"
+
+
+@pytest.fixture
+def controller() -> MagicMock:
+    """Build a thermostat controller whose set_state records what it was asked for."""
+    c = MagicMock()
+    c.set_state = AsyncMock(return_value=None)
+    return c
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (FAN_AUTO, pyadc.thermostat.ThermostatFanMode.AUTO),
+        (FAN_ON, pyadc.thermostat.ThermostatFanMode.ON),
+        (FAN_CIRCULATE, pyadc.thermostat.ThermostatFanMode.CIRCULATE),
+    ],
+)
+async def test_every_supported_fan_mode_reaches_the_api(
+    controller: MagicMock, requested: str, expected: object
+) -> None:
+    """AUTO is 0 and was dropped by a truthiness test; all three must call out."""
+    await set_fan_mode_fn(controller, "thermostat-1", requested)
+
+    controller.set_state.assert_awaited_once_with(
+        "thermostat-1", fan_mode=expected, fan_mode_duration=0
+    )
+
+
+async def test_unknown_fan_mode_does_not_call_the_api(controller: MagicMock) -> None:
+    """A mode this integration does not map must not reach the API at all."""
+    await set_fan_mode_fn(controller, "thermostat-1", "turbo")
+
+    controller.set_state.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (HVACMode.OFF, pyadc.thermostat.ThermostatState.OFF),
+        (HVACMode.HEAT, pyadc.thermostat.ThermostatState.HEAT),
+        (HVACMode.COOL, pyadc.thermostat.ThermostatState.COOL),
+        (HVACMode.HEAT_COOL, pyadc.thermostat.ThermostatState.AUTO),
+    ],
+)
+async def test_every_supported_hvac_mode_reaches_the_api(
+    controller: MagicMock, requested: HVACMode, expected: object
+) -> None:
+    """Same gate one function above; correct today only because OFF is 1."""
+    await set_hvac_mode_fn(controller, "thermostat-1", requested)
+
+    controller.set_state.assert_awaited_once_with("thermostat-1", state=expected)
+
+
+async def test_unknown_hvac_mode_does_not_call_the_api(controller: MagicMock) -> None:
+    """HVACMode.DRY is not in the map and must be dropped."""
+    await set_hvac_mode_fn(controller, "thermostat-1", HVACMode.DRY)
+
+    controller.set_state.assert_not_awaited()
+
+
+def test_the_zero_valued_member_that_caused_this_is_still_zero() -> None:
+    """If AUTO stops being 0 the bug is gone, and so is the reason for these tests."""
+    assert pyadc.thermostat.ThermostatFanMode.AUTO == 0
+    assert not pyadc.thermostat.ThermostatFanMode.AUTO


### PR DESCRIPTION
Closes #99.

`ThermostatFanMode` is an `IntEnum` and `AUTO` is 0. `set_fan_mode_fn` looked the
requested mode up in a dict, then gated the API call on the result's truthiness:

```python
if requested_fan_mode := fan_mode_map.get(fan_mode):
```

`"auto"` resolves correctly to `ThermostatFanMode.AUTO`, which is falsy, so the
function returned having called nothing and raised nothing. From Home Assistant the
service call succeeds and an automation reports that it fired; the thermostat never
hears about it. `"on"` and `"circulate"` are 1 and 2, which is why this reads as an
intermittent fault rather than a broken service.

`set_hvac_mode_fn` one function above has the identical test. `ThermostatState.OFF`
is 1, so it is correct today. Changed alongside, because the next zero-valued member
added to that enum would fail exactly as silently.

### Tests

Adds `tests/test_climate_set_modes.py`: every supported mode must reach the API, an
unsupported one must not, and one case asserts `AUTO` is still the falsy 0 so these
tests retire themselves if that ever changes. The `auto` case fails without this
change.

Full suite: 116 passed.