### PR TITLE
Make the camera token refresh interval configurable (#93)

### DIFF
--- a/custom_components/alarmdotcom/camera.py
+++ b/custom_components/alarmdotcom/camera.py
@@ -14,7 +14,11 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN
+from .const import (
+    CONF_CAMERA_TOKEN_REFRESH_INTERVAL,
+    CONF_OPTIONS_DEFAULT,
+    DOMAIN,
+)
 
 if TYPE_CHECKING:
     from .camera_api import AlarmCameraSession
@@ -26,7 +30,6 @@ PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
 
-TOKEN_REFRESH_INTERVAL = timedelta(minutes=30)
 
 
 async def async_setup_entry(
@@ -79,8 +82,19 @@ async def async_setup_entry(
         _LOGGER.debug("No cameras found for entry %s, skipping camera setup.", entry.entry_id)
         return
 
+    # User-configurable via the options flow (#93); the entry reloads on change.
+    refresh_interval = timedelta(
+        minutes=entry.options.get(
+            CONF_CAMERA_TOKEN_REFRESH_INTERVAL,
+            CONF_OPTIONS_DEFAULT[CONF_CAMERA_TOKEN_REFRESH_INTERVAL],
+        )
+    )
+
     async_add_entities(
-        [AlarmDotComCamera(camera_session, cam, entry.entry_id) for cam in cameras]
+        [
+            AlarmDotComCamera(camera_session, cam, entry.entry_id, refresh_interval)
+            for cam in cameras
+        ]
     )
 
 
@@ -91,7 +105,11 @@ class AlarmDotComCamera(Camera):
     _attr_supported_features = CameraEntityFeature.ON_OFF
 
     def __init__(
-        self, session: AlarmCameraSession, info: dict, entry_id: str
+        self,
+        session: AlarmCameraSession,
+        info: dict,
+        entry_id: str,
+        token_refresh_interval: timedelta,
     ) -> None:
         """Initialize the camera."""
         super().__init__()
@@ -99,6 +117,7 @@ class AlarmDotComCamera(Camera):
         self._id = info["id"]
         self._name = info.get("description", self._id)
         self._entry_id = entry_id
+        self._token_refresh_interval = token_refresh_interval
 
         self._attr_unique_id = f"{entry_id}_camera_{self._id}"
         self._attr_name = self._name
@@ -124,7 +143,7 @@ class AlarmDotComCamera(Camera):
         self._remove_refresh = async_track_time_interval(
             self.hass,
             self._async_refresh_tokens,
-            TOKEN_REFRESH_INTERVAL,
+            self._token_refresh_interval,
         )
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/alarmdotcom/config_flow.py
+++ b/custom_components/alarmdotcom/config_flow.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_ARM_HOME,
     CONF_ARM_MODE_OPTIONS,
     CONF_ARM_NIGHT,
+    CONF_CAMERA_TOKEN_REFRESH_INTERVAL,
     CONF_FULL_STATE_POLL_INTERVAL,
     CONF_MFA_TOKEN,
     CONF_OPTIONS_DEFAULT,
@@ -449,6 +450,15 @@ class ADCOptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                 ): selector.selector(
                     {"number": {"min": 1, "max": 60, "step": 1, "unit_of_measurement": "minutes"}}
+                ),
+                vol.Required(
+                    CONF_CAMERA_TOKEN_REFRESH_INTERVAL,
+                    default=self.options.get(
+                        CONF_CAMERA_TOKEN_REFRESH_INTERVAL,
+                        CONF_OPTIONS_DEFAULT[CONF_CAMERA_TOKEN_REFRESH_INTERVAL],
+                    ),
+                ): selector.selector(
+                    {"number": {"min": 5, "max": 120, "step": 1, "unit_of_measurement": "minutes"}}
                 ),
             }
         )

--- a/custom_components/alarmdotcom/const.py
+++ b/custom_components/alarmdotcom/const.py
@@ -66,6 +66,10 @@ CONF_NO_ENTRY_DELAY = "no_entry_delay"
 # just the fallback defaults used before a user has ever set an option.
 CONF_ACTIVITY_POLL_INTERVAL = "activity_poll_interval"  # seconds
 CONF_FULL_STATE_POLL_INTERVAL = "full_state_poll_interval"  # minutes
+# How often each camera re-fetches its WebRTC stream tokens. Alarm.com does
+# not document the token lifetime; 30 minutes is the value that was hardcoded
+# before this became an option (#93).
+CONF_CAMERA_TOKEN_REFRESH_INTERVAL = "camera_token_refresh_interval"  # minutes  # noqa: S105
 CONF_ARM_MODE_OPTIONS = {
     CONF_FORCE_BYPASS: "Force Bypass",
     CONF_SILENT_ARM: "Arm Silently",
@@ -79,6 +83,7 @@ CONF_OPTIONS_DEFAULT = {
     CONF_ARM_NIGHT: [],
     CONF_ACTIVITY_POLL_INTERVAL: 15,
     CONF_FULL_STATE_POLL_INTERVAL: 5,
+    CONF_CAMERA_TOKEN_REFRESH_INTERVAL: 30,
 }
 
 DATA_HUB = "connection"

--- a/custom_components/alarmdotcom/strings.json
+++ b/custom_components/alarmdotcom/strings.json
@@ -59,6 +59,20 @@
                 "data_description": {
                     "arm_night_options": "Arm Night may not be available on all partitions."
                 }
+            },
+            "polling": {
+                "title": "Polling & Refresh Intervals",
+                "description": "How often the integration asks Alarm.com for data it does not receive by push.",
+                "data": {
+                    "activity_poll_interval": "Activity feed poll interval",
+                    "full_state_poll_interval": "Full state refresh interval",
+                    "camera_token_refresh_interval": "Camera token refresh interval"
+                },
+                "data_description": {
+                    "activity_poll_interval": "Seconds between activity feed polls. Uses an undocumented endpoint; raise this if you see rate limiting.",
+                    "full_state_poll_interval": "Minutes between full state refreshes, a safety net for missed push events.",
+                    "camera_token_refresh_interval": "Minutes between WebRTC token refreshes for each camera. Lower it if streams stop working before the next refresh."
+                }
             }
         }
     },

--- a/custom_components/alarmdotcom/translations/en.json
+++ b/custom_components/alarmdotcom/translations/en.json
@@ -65,6 +65,20 @@
                 "data_description": {
                     "arm_night_options": "Note: Night mode is only compatible with specific Alarm.com partitions."
                 }
+            },
+            "polling": {
+                "title": "Polling & Refresh Intervals",
+                "description": "How often the integration asks Alarm.com for data it does not receive by push.",
+                "data": {
+                    "activity_poll_interval": "Activity feed poll interval",
+                    "full_state_poll_interval": "Full state refresh interval",
+                    "camera_token_refresh_interval": "Camera token refresh interval"
+                },
+                "data_description": {
+                    "activity_poll_interval": "Seconds between activity feed polls. Uses an undocumented endpoint; raise this if you see rate limiting.",
+                    "full_state_poll_interval": "Minutes between full state refreshes, a safety net for missed push events.",
+                    "camera_token_refresh_interval": "Minutes between WebRTC token refreshes for each camera. Lower it if streams stop working before the next refresh."
+                }
             }
         }
     },

--- a/tests/test_camera_token_refresh.py
+++ b/tests/test_camera_token_refresh.py
@@ -1,0 +1,46 @@
+"""Camera token refresh cadence follows the option (#93)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+# homeassistant.components.camera imports PyTurboJPEG at module level, and the
+# test helper does not install component requirements. Skip rather than fail
+# where it is absent; the options-flow tests still cover the option itself.
+pytest.importorskip("turbojpeg")
+
+from custom_components.alarmdotcom.camera import AlarmDotComCamera, async_setup_entry
+from custom_components.alarmdotcom.const import DOMAIN
+
+
+def _session_with_one_camera() -> MagicMock:
+    session = MagicMock()
+    session.session_generation = 1
+    session.get_camera_list = AsyncMock(return_value=[{"id": "cam-1", "description": "Porch"}])
+    return session
+
+
+async def _setup(hass: HomeAssistant, options: dict) -> list[AlarmDotComCamera]:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options=options, title="Alarm.com")
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"camera_session": _session_with_one_camera()}
+    added: list[AlarmDotComCamera] = []
+    await async_setup_entry(hass, entry, added.extend)
+    return added
+
+
+async def test_setup_passes_the_configured_interval_to_each_camera(hass: HomeAssistant) -> None:
+    """A user who set 10 minutes gets a 10-minute refresh."""
+    (camera,) = await _setup(hass, {"camera_token_refresh_interval": 10})
+    assert camera._token_refresh_interval == timedelta(minutes=10)
+
+
+async def test_setup_falls_back_to_thirty_minutes_when_unset(hass: HomeAssistant) -> None:
+    """An entry configured before this option existed keeps the old hardcoded cadence."""
+    (camera,) = await _setup(hass, {})
+    assert camera._token_refresh_interval == timedelta(minutes=30)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -19,6 +19,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.alarmdotcom._pyalarmdotcomajax as pyadc
 from custom_components.alarmdotcom.const import (
+    CONF_CAMERA_TOKEN_REFRESH_INTERVAL,
+    CONF_OPTIONS_DEFAULT,
     CONF_ARM_AWAY,
     CONF_ARM_CODE,
     CONF_ARM_HOME,
@@ -264,3 +266,33 @@ async def test_options_flow_polling_step_accepts_custom_intervals(hass: HomeAssi
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"]["activity_poll_interval"] == 60
     assert result["data"]["full_state_poll_interval"] == 15
+
+
+async def test_options_flow_polling_step_persists_camera_token_refresh(hass: HomeAssistant) -> None:
+    """The camera token refresh interval (#93) is set on the polling step and persisted."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data=VALID_CREDS)
+    entry.add_to_hass(hass)
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"arm_code": "", "remove_arm_code": False}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"arm_home_options": [], "arm_away_options": [], "arm_night_options": []},
+    )
+    assert result["step_id"] == "polling"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "activity_poll_interval": 15,
+            "full_state_poll_interval": 5,
+            "camera_token_refresh_interval": 10,
+        },
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"]["camera_token_refresh_interval"] == 10
+
+
+def test_camera_token_refresh_default_is_the_previously_hardcoded_thirty_minutes() -> None:
+    """Existing installs must keep the 30-minute cadence they had before this was an option."""
+    assert CONF_OPTIONS_DEFAULT[CONF_CAMERA_TOKEN_REFRESH_INTERVAL] == 30


### PR DESCRIPTION
Closes #93.

Each camera re-fetched its WebRTC stream tokens every 30 minutes, fixed in a module
constant. Alarm.com doesn't document the token lifetime, so anyone whose streams died
before the next refresh had no recourse short of a code change.

The interval now lives on the **polling** step of the options flow, alongside the two
intervals already there, bounded 5–120 minutes. The default is 30, so existing installs
keep exactly the cadence they had. The entry already reloads on an options change, so a
new value takes effect on save.

One thing this touches beyond the request: the polling step had no strings at all and
rendered raw field names. This adds a title, labels and descriptions for all three of
its fields — it seemed wrong to label only the new one.

### Tests

- options flow persists the field
- the default is the previously hardcoded 30
- the camera platform passes the configured interval to each entity, and falls back to
  30 when the option is absent

The camera-platform test uses `pytest.importorskip("turbojpeg")`: HA's camera component
imports PyTurboJPEG at module level and the test helper doesn't install component
requirements, so it skips rather than fails on a bare CI runner. The two options-flow
tests cover the option itself regardless.

Full suite: 110 passed.